### PR TITLE
Update GitHub link in app config

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -37,7 +37,7 @@ export default defineAppConfig({
     colorMode: true,
     links: [{
       'icon': 'i-simple-icons-github',
-      'to': 'https://github.com/glueful/docs',
+      'to': 'https://github.com/glueful',
       'target': '_blank',
       'aria-label': 'GitHub'
     }]


### PR DESCRIPTION
Changed the GitHub link in the app configuration from the docs repository to the main glueful repository.