### PR TITLE
Update docs to match API skeleton and starter app

### DIFF
--- a/content/1.getting-started/1.installation.md
+++ b/content/1.getting-started/1.installation.md
@@ -1,200 +1,60 @@
 ---
 title: Installation
-description: Complete guide to installing and setting up Glueful
+description: Install Glueful with the API skeleton or as a framework package
 ---
 
-This guide will walk you through installing Glueful and setting up your development environment.
+Glueful has two entry points:
 
-## System Requirements
+1. **`glueful/api-skeleton`** for most users. This is the recommended path.
+2. **`glueful/framework`** if you are embedding the framework into an existing project.
 
-### Minimum Requirements
+## Requirements
 
-- **PHP**: 8.3 or higher
-- **Composer**: 2.0 or higher  
-- **Memory**: 512MB RAM minimum, 1GB+ recommended
-- **Database**: SQLite 3.8+ (built into PHP) or PostgreSQL 12+, MySQL 5.7+
+- PHP 8.3+
+- Composer 2+
 
-### Required PHP Extensions
+## Recommended: API Skeleton
 
-Glueful requires these PHP extensions (most are included by default):
-
-```bash
-# Core extensions (usually pre-installed)
-- json          # JSON handling
-- mbstring      # Multi-byte string functions
-- openssl       # Encryption and security
-- PDO           # Database abstraction
-- curl          # HTTP client functionality
-- xml           # XML processing
-- zip           # Archive handling
-
-# Database extensions (at least one required)
-- pdo_sqlite    # SQLite support (default, included with PHP)
-- pdo_mysql     # MySQL/MariaDB support (optional)
-- pdo_pgsql     # PostgreSQL support (optional)
-
-# Recommended for enhanced functionality
-- redis         # Redis caching support
-- gd            # Image processing
-- intl          # Internationalization
-- bcmath        # Precise decimal calculations
-```
-
-### Checking Your System
-
-Verify your system is ready:
+Create a new project from the starter app:
 
 ```bash
-# Check PHP version
-php -v
-
-# Check required extensions
-php -m | grep -E "(json|mbstring|openssl|PDO|curl|xml|zip)"
-
-# Check Composer
-composer --version
-
-# Check memory limit
-php -r "echo 'Memory Limit: ' . ini_get('memory_limit') . PHP_EOL;"
+composer create-project glueful/api-skeleton my-api
+cd my-api
 ```
 
-## Installation Methods
+The skeleton already includes:
 
-### Prerequisites
+- a CLI entrypoint at `glueful`
+- framework bootstrap in `bootstrap/app.php`
+- example routes in `routes/api.php`
+- example controller in `app/Controllers/WelcomeController.php`
+- default SQLite storage in `storage/database/glueful.sqlite`
 
-Before installing Glueful, you need to have PHP and Composer installed on your system.
-
-#### Installing PHP (8.3 or higher)
-
-::code-group{.w-full}
-
-```bash [macOS]
-# Using Homebrew
-brew install php
-
-# Verify installation
-php -v
-```
-
-```powershell [Windows]
-# Option 1: Manual Installation
-# 1. Download the PHP installer from https://windows.php.net/download/
-# 2. Add PHP to your PATH environment variable
-# 3. Verify installation: php -v
-
-# Option 2: Using PowerShell with Chocolatey
-# Install Chocolatey if not already installed
-Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-
-# Install PHP 8.3
-choco install php -y --version=8.3.0
-
-# Verify installation
-php -v
-```
-
-```bash [Linux]
-sudo apt update
-sudo apt install php php-cli php-fpm php-json php-common php-mysql php-zip php-mbstring php-curl php-xml php-bcmath
-php -v
-```
-
-::
-
-#### Installing Composer
-
-::code-group{.w-full}
-
-```bash [macOS]
-# Using Homebrew
-brew install composer
-
-# Manual installation
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('sha384', 'composer-setup.php') === 'e21205b207c3ff031906575712edab6f13eb0b361f2085f1f1237b7126d785e826a450292b6cfd1d64d92e6563bbde02') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-php composer-setup.php
-php -r "unlink('composer-setup.php');"
-sudo mv composer.phar /usr/local/bin/composer
-```
-
-```powershell [Windows]
-# Option 1: Using the Installer
-# 1. Download and run the Composer Windows Installer from https://getcomposer.org/download/
-# 2. Follow the installation wizard
-
-# Option 2: Using PowerShell with Chocolatey
-# Install Chocolatey if not already installed
-# Make sure Chocolatey is installed (see PHP installation above)
-
-# Install Composer
-choco install composer -y
-
-# Verify installation
-composer --version
-
-# Option 3: Manual Installation
-# Download and verify the installer
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('sha384', 'composer-setup.php') === 'e21205b207c3ff031906575712edab6f13eb0b361f2085f1f1237b7126d785e826a450292b6cfd1d64d92e6563bbde02') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-php composer-setup.php
-php -r "unlink('composer-setup.php');"
-# Move Composer to a global location
-mkdir -Force $env:APPDATA\Composer
-move composer.phar $env:APPDATA\Composer\composer.phar
-$composerPath = @"
-@php "%~dp0composer.phar" %*
-"@
-Set-Content -Path "$env:APPDATA\Composer\composer.bat" -Value $composerPath
-$env:Path += ";$env:APPDATA\Composer"
-[Environment]::SetEnvironmentVariable("Path", $env:Path, [EnvironmentVariableTarget]::User)
-# Verify installation
-composer --version
-```
-
-```bash [Linux]
-# Download the installer
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('sha384', 'composer-setup.php') === 'e21205b207c3ff031906575712edab6f13eb0b361f2085f1f1237b7126d785e826a450292b6cfd1d64d92e6563bbde02') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-
-# Install Composer
-php composer-setup.php
-
-# Clean up and move to global location
-php -r "unlink('composer-setup.php');"
-sudo mv composer.phar /usr/local/bin/composer
-
-# Verify installation
-composer --version
-```
-
-::
-
-### Method 1: API Skeleton (Recommended)
-
-The fastest way to get started is with the pre-configured API skeleton:
+### First Run
 
 ```bash
-# Create a new Glueful project from the API skeleton (recommended)
-composer create-project glueful/api-skeleton my-project
-cd my-project
-# Start the development server
+composer install
+php glueful install --quiet
+php glueful serve
 ```
 
-Your API will be available at `http://127.0.0.1:8080`
-
-### Method 2: Framework Only
-
-Install just the framework into an existing project:
+Then verify the starter routes:
 
 ```bash
-# Install via Composer
+curl http://127.0.0.1:8080/welcome
+curl http://127.0.0.1:8080/v1/status
+curl http://127.0.0.1:8080/health
+```
+
+## Alternative: Framework Only
+
+Install the framework package into an existing PHP project:
+
+```bash
 composer require glueful/framework
-
-# Create minimal bootstrap (optional)
-mkdir -p config public routes
 ```
 
-Then create a basic `public/index.php`:
+Create a minimal bootstrap:
 
 ```php
 <?php
@@ -203,14 +63,13 @@ declare(strict_types=1);
 use Glueful\Framework;
 use Symfony\Component\HttpFoundation\Request;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
-$framework = Framework::create(dirname(__DIR__))
-    ->withConfigDir(__DIR__ . '/../config')
+$framework = Framework::create(__DIR__)
+    ->withConfigDir(__DIR__ . '/config')
     ->withEnvironment($_ENV['APP_ENV'] ?? 'development');
 
 $app = $framework->boot();
-
 
 $request = Request::createFromGlobals();
 $response = $app->handle($request);
@@ -218,226 +77,10 @@ $response->send();
 $app->terminate($request, $response);
 ```
 
-And create `routes/api.php` for your routes:
+Use this path only if you already know the project structure you want. If not, use the API skeleton.
 
-```php
-<?php
+## What To Read Next
 
-use Glueful\Http\Response;
-
-/** @var \Glueful\Routing\Router $router */
-
-$router->get('/', function() {
-    return new Response(['status' => 'ok']);
-});
-```
-
-## Initial Setup
-
-### Environment Configuration
-
-1. **Copy the environment file**:
-```bash
-cp .env.example .env
-```
-
-2. **Generate application keys**:
-```bash
-php glueful generate:key
-```
-
-This will automatically generate secure keys for `APP_KEY`, `JWT_KEY`, and `TOKEN_SALT`.
-
-3. **Configure your database** (if not using SQLite):
-
-```bash
-# For PostgreSQL
-DB_CONNECTION=pgsql
-DB_HOST=localhost
-DB_PORT=5432
-DB_DATABASE=your_database
-DB_USERNAME=your_username
-DB_PASSWORD=your_password
-
-# For MySQL
-DB_CONNECTION=mysql
-DB_HOST=localhost
-DB_PORT=3306
-DB_DATABASE=your_database
-DB_USERNAME=your_username
-DB_PASSWORD=your_password
-```
-
-### Database Setup
-
-```bash
-# Run migrations to set up database tables
-php glueful migrate:run
-
-# Optional: Seed with sample data
-php glueful migrate:seed
-```
-
-### System Validation
-
-Verify your installation:
-
-```bash
-# Comprehensive system check
-php glueful system:check
-
-# Detailed diagnostics
-php glueful system:check --verbose
-
-# Production readiness check
-php glueful system:check --production
-```
-
-## Development Server
-
-Start the built-in development server:
-
-```bash
-# Default (127.0.0.1:8080)
-php glueful serve
-
-# Custom host and port
-php glueful serve --host=0.0.0.0 --port=3000
-
-# With automatic reloading
-php glueful serve --reload
-```
-
-## Testing Your Installation
-
-Visit these endpoints to verify everything works:
-
-- **Welcome**: `http://127.0.0.1:8080/`
-- **Health Check**: `http://127.0.0.1:8080/health`
-- **System Info**: `http://127.0.0.1:8080/health/system` (development only)
-
-## IDE Setup
-
-### VS Code
-
-Install recommended extensions:
-
-1. **PHP Intelephense** - Advanced PHP language support
-2. **PHP Debug** - Debugging support
-3. **REST Client** - API testing
-
-Create `.vscode/settings.json`:
-
-```json
-{
-    "php.validate.executablePath": "/usr/local/bin/php",
-    "php.suggest.basic": false,
-    "intelephense.files.maxSize": 3000000,
-    "files.associations": {
-        "*.php": "php"
-    }
-}
-```
-
-### PhpStorm
-
-Glueful works out of the box with PhpStorm. Configure:
-
-1. Set PHP version to 8.3+
-2. Enable Composer support
-3. Configure code style to PSR-12
-
-## Environment-Specific Setup
-
-### Development
-
-```bash
-# .env
-APP_ENV=development
-APP_DEBUG=true
-API_DOCS_ENABLED=true
-```
-
-### Production
-
-```bash
-# .env
-APP_ENV=production
-# APP_DEBUG automatically set to false
-# API_DOCS_ENABLED automatically set to false
-FORCE_HTTPS=true
-
-# Set strong, unique keys
-APP_KEY=your_secure_32_character_key_here
-JWT_KEY=your_secure_jwt_key_base64_encoded
-```
-
-## Common Installation Issues
-
-### Memory Limits
-
-If you encounter memory issues:
-
-```bash
-# Increase PHP memory limit temporarily
-php -d memory_limit=512M glueful install
-
-# Or permanently in php.ini
-memory_limit = 512M
-```
-
-### Extension Missing
-
-Install missing PHP extensions:
-
-```bash
-# Ubuntu/Debian
-sudo apt install php8.3-{mbstring,xml,curl,zip,sqlite3}
-
-# macOS with Homebrew
-brew install php@8.3
-
-# CentOS/RHEL
-sudo yum install php82-{mbstring,xml,curl,zip,sqlite}
-```
-
-### Composer Issues
-
-```bash
-# Clear Composer cache
-composer clear-cache
-
-# Update Composer itself
-composer self-update
-
-# Install with verbose output
-composer install --verbose
-```
-
-### Permission Issues
-
-```bash
-# Set proper permissions for storage
-chmod -R 755 storage/
-chmod -R 755 bootstrap/cache/
-
-# On some systems, you may need:
-sudo chown -R www-data:www-data storage/ bootstrap/cache/
-```
-
-## Next Steps
-
-Once installed, you're ready to:
-
-1. **[Configure your application](/advanced/configuration)** - Set up databases, caching, and more
-2. **[Follow the tutorial](/cookbook)** - Build your first API
-3. **[Learn the core concepts](/essentials)** - Understand Glueful's core building blocks
-
-## Getting Help
-
-If you encounter issues:
-
-- Check the [troubleshooting guide](/cookbook/setup#troubleshooting)
-- Review the [system requirements](#system-requirements)
-- Join our [community discussions](https://github.com/glueful/framework/discussions)
-- Report bugs on [GitHub Issues](https://github.com/glueful/framework/issues)
+- [Quickstart](/getting-started/quickstart)
+- [Build Your First API](/getting-started/first-api)
+- [Routing](/essentials/routing)

--- a/content/1.getting-started/2.quickstart.md
+++ b/content/1.getting-started/2.quickstart.md
@@ -1,143 +1,76 @@
 ---
 title: Quickstart
-description: Build your first API
+description: Get a Glueful API running in a few minutes
 ---
 
-Get your first Glueful API running.
+This quickstart uses **`glueful/api-skeleton`**, which is the recommended way to start.
 
-## Prerequisites
-
-- PHP 8.3 or higher
-- Composer 2+
-- SQLite (included with PHP)
-
-## Installation
+## Create the Project
 
 ```bash
-# Clone the API skeleton
 composer create-project glueful/api-skeleton my-api
 cd my-api
-
-# Install dependencies
 composer install
-
-# Initialize the application
 php glueful install --quiet
-
-# Start the development server
 php glueful serve
 ```
 
-Your API is now running at `http://127.0.0.1:8080`
+Your API should now be running at `http://127.0.0.1:8080`.
 
-## Your First Endpoint
+## Verify the Starter Endpoints
 
-Create a simple "Hello World" endpoint in `routes/api.php`:
+The skeleton ships with a couple of routes out of the box:
+
+```bash
+curl http://127.0.0.1:8080/welcome
+curl http://127.0.0.1:8080/v1/status
+curl http://127.0.0.1:8080/health
+```
+
+## Add Your First Route
+
+Open `routes/api.php` and add a route inside the existing `v1` group:
 
 ```php
 <?php
 
-// $router is provided by the route bootstrap context
+use Glueful\Routing\Router;
 use Glueful\Http\Response;
+use App\Controllers\WelcomeController;
 
-$router->get('/hello', function() {
-    return new Response([
-        'message' => 'Hello, Glueful!',
-        'timestamp' => date('c')
-    ]);
+$router->group(['prefix' => 'v1'], function (Router $router) {
+    $router->get('/status', [WelcomeController::class, 'status']);
+
+    $router->get('/hello', function () {
+        return Response::success([
+            'message' => 'Hello from Glueful',
+            'timestamp' => date('c'),
+        ]);
+    });
 });
+
+$router->get('/welcome', [WelcomeController::class, 'index']);
 ```
 
 Test it:
 
 ```bash
-curl http://127.0.0.1:8080/hello
+curl http://127.0.0.1:8080/v1/hello
 ```
 
-## Built-in CRUD APIs
+## Generate New Code
 
-Glueful automatically creates REST APIs for your database tables. No code needed!
-
-### Create a Tasks Table
+Glueful’s current generators use the `scaffold:*` namespace:
 
 ```bash
-php glueful migrate:create CreateTasksTable
+php glueful scaffold:controller UserController
+php glueful scaffold:model User
+php glueful scaffold:request CreateUserRequest
 ```
-
-Edit the migration file:
-
-```php
-<?php
-
-namespace Glueful\Database\Migrations;
-
-use Glueful\Database\Migrations\MigrationInterface;
-use Glueful\Database\Schema\Interfaces\SchemaBuilderInterface;
-
-class CreateTasksTable implements MigrationInterface
-{
-    public function up(SchemaBuilderInterface $schema): void
-    {
-        $schema->createTable('tasks', function ($table) {
-            $table->bigInteger('id')->primary()->autoIncrement();
-            $table->string('uuid', 12)->unique();
-            $table->string('title', 255);
-            $table->text('description')->nullable();
-            $table->boolean('completed')->default(false);
-            $table->timestamp('created_at')->default('CURRENT_TIMESTAMP');
-            $table->timestamp('updated_at')->nullable();
-        });
-    }
-
-    public function down(SchemaBuilderInterface $schema): void
-    {
-        $schema->dropTable('tasks');
-    }
-}
-```
-
-Run the migration:
-
-```bash
-php glueful migrate:run
-```
-
-### Instant REST API
-
-You now have a complete CRUD API automatically:
-
-```bash
-# List tasks
-curl http://localhost:8000/tasks
-
-# Create a task
-curl -X POST http://localhost:8000/tasks \
-  -H "Content-Type: application/json" \
-  -d '{"title": "Learn Glueful", "description": "Build awesome APIs"}'
-
-# Get single task
-curl http://localhost:8000/tasks/{uuid}
-
-# Update task
-curl -X PUT http://localhost:8000/tasks/{uuid} \
-  -H "Content-Type: application/json" \
-  -d '{"completed": true}'
-
-# Delete task
-curl -X DELETE http://localhost:8000/tasks/{uuid}
-```
-
-All with:
-- ✅ Automatic pagination
-- ✅ Filtering and sorting
-- ✅ Validation
-- ✅ Error handling
-- ✅ UUID-based IDs
 
 ## Next Steps
 
-- [Installation Guide](installation) - Detailed setup instructions
-- [Essentials](/essentials) - Learn core concepts
-- [Examples](/cookbook) - Real-world examples
-
-Ready to build? Start with the [Essentials](/essentials) to learn routing, controllers, and database operations.
+- [Build Your First API](/getting-started/first-api)
+- [Routing](/essentials/routing)
+- [Controllers](/essentials/controllers)
+- [CLI Reference](/cli-reference)

--- a/content/1.getting-started/3.first-api.md
+++ b/content/1.getting-started/3.first-api.md
@@ -1,550 +1,119 @@
 ---
 title: Build Your First API
-description: Step-by-step tutorial to build a complete REST API
+description: Add a real controller and route to the API skeleton
 ---
 
-Build a complete task management API from scratch with authentication, validation, and database operations.
+This guide stays close to the actual `glueful/api-skeleton` structure so you can copy it directly.
 
-## What You'll Build
-
-A RESTful API with:
-- User authentication (JWT)
-- CRUD operations for tasks
-- Input validation
-- Database migrations
-- Error handling
-
-**Time:** 15 minutes
-
-## Prerequisites
-
-- Glueful installed ([Installation Guide](installation))
-- Basic PHP knowledge
-- Database configured (MySQL, PostgreSQL, or SQLite)
-
-## Step 1: Create Project
+## Start From the Skeleton
 
 ```bash
 composer create-project glueful/api-skeleton task-api
 cd task-api
+composer install
+php glueful install --quiet
 ```
 
-Configure `.env`:
+## Create a Controller
 
-```env
-APP_NAME="Task API"
-APP_ENV=development
-APP_DEBUG=true
-
-DB_DRIVER=mysql
-DB_HOST=localhost
-DB_DATABASE=task_api
-DB_USERNAME=root
-DB_PASSWORD=
-```
-
-## Step 2: Create Database Migration
-
-Create users table:
-
-```bash
-php glueful migrate:create CreateUsersTable
-```
-
-Edit the generated migration in `database/migrations/`:
+Create `app/Controllers/TaskController.php`:
 
 ```php
 <?php
 
-use Glueful\Database\Schema\Interfaces\SchemaBuilderInterface;
-use Glueful\Database\Migrations\MigrationInterface;
-
-class CreateUsersTable implements MigrationInterface
-{
-    public function up(SchemaBuilderInterface $schema): void
-    {
-        $schema->createTable('users', function ($table) {
-            $table->bigInteger('id')->primary()->autoIncrement();
-            $table->string('uuid', 16)->unique();
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->string('password');
-            $table->timestamps();
-        });
-    }
-
-    public function down(SchemaBuilderInterface $schema): void
-    {
-        $schema->dropTable('users');
-    }
-
-    public function getDescription(): string
-    {
-        return 'Create users table';
-    }
-}
-```
-
-Create tasks table:
-
-```bash
-php glueful migrate:create CreateTasksTable
-```
-
-```php
-<?php
-
-use Glueful\Database\Schema\Interfaces\SchemaBuilderInterface;
-use Glueful\Database\Migrations\MigrationInterface;
-
-class CreateTasksTable implements MigrationInterface
-{
-    public function up(SchemaBuilderInterface $schema): void
-    {
-        $schema->createTable('tasks', function ($table) {
-            $table->bigInteger('id')->primary()->autoIncrement();
-            $table->string('uuid', 16)->unique();
-            $table->bigInteger('user_id');
-            $table->string('title');
-            $table->text('description')->nullable();
-            $table->enum('status', ['pending', 'in_progress', 'completed'])->default('pending');
-            $table->timestamp('due_date')->nullable();
-            $table->timestamps();
-            $table->index('user_id');
-            $table->index('status');
-        });
-    }
-
-    public function down(SchemaBuilderInterface $schema): void
-    {
-        $schema->dropTable('tasks');
-    }
-
-    public function getDescription(): string
-    {
-        return 'Create tasks table';
-    }
-}
-```
-
-Run migrations:
-
-```bash
-php glueful migrate:run
-```
-
-## Step 3: Create Controllers
-
-Create auth controller:
-
-`app/Controllers/AuthController.php`:
-
-```php
-<?php
+declare(strict_types=1);
 
 namespace App\Controllers;
 
-use Glueful\Http\Request; // Adjust if using Symfony Request wrapper
+use Glueful\Controllers\BaseController;
 use Glueful\Http\Response;
-use Glueful\Auth\JWTService;
-use Glueful\Helpers\Utils;
+use Symfony\Component\HttpFoundation\Request;
 
-class AuthController
+class TaskController extends BaseController
 {
-    public function register(Request $request)
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private static array $tasks = [];
+
+    public function index(Request $request): Response
     {
-    $validated = $this->validate($request->all(), [
-            'name' => 'required|string|min:2',
-            'email' => 'required|email|unique:users,email',
-            'password' => 'required|string|min:8',
-        ]);
-
-        $idData = [
-            'uuid' => Utils::generateNanoID(16),
-        ];
-        $insertData = [
-            'name' => $validated['name'],
-            'email' => $validated['email'],
-            'password' => password_hash($validated['password'], PASSWORD_BCRYPT),
-        ];
-        db()->from('users')->insert(array_merge($idData, $insertData));
-        $user = db()->from('users')->where('email', $validated['email'])->limit(1)->get()[0] ?? null;
-
-        $token = JWTService::generate([
-            'user_id' => $user['id'] ?? null,
-            'email' => $user['email'] ?? null,
-            'uuid' => $user['uuid'] ?? null,
-        ]);
-
-        return Response::created([
-            'user' => [
-                'id' => $user['uuid'],
-                'name' => $user['name'],
-                'email' => $user['email'],
-            ],
-            'token' => $token,
-        ]);
+        return $this->success(self::$tasks);
     }
 
-    public function login(Request $request)
+    public function store(Request $request): Response
     {
-        $validated = $this->validate($request->all(), [
-            'email' => 'required|email',
-            'password' => 'required',
-        ]);
+        $data = $this->getRequestData();
 
-        $user = db()->from('users')
-            ->where('email', $validated['email'])
-            ->limit(1)
-            ->get()[0] ?? null;
-
-        if (!$user || !password_verify($validated['password'], $user['password'])) {
-            return Response::error('Invalid credentials', 401);
+        if ($error = $this->validateRequest($data, [
+            'title' => 'required|max:255',
+        ])) {
+            return $error;
         }
 
-        $token = JWTService::generate([
-            'user_id' => $user['id'],
-            'email' => $user['email'],
-            'uuid' => $user['uuid'] ?? null,
-        ]);
+        $task = [
+            'id' => count(self::$tasks) + 1,
+            'title' => $data['title'],
+            'completed' => false,
+            'created_at' => date('c'),
+        ];
 
-        return Response::success([
-            'user' => [
-                'id' => $user['uuid'],
-                'name' => $user['name'],
-                'email' => $user['email'],
-            ],
-            'token' => $token,
-        ]);
-    }
+        self::$tasks[] = $task;
 
-    protected function validate(array $data, array $rules)
-    {
-        $validator = new \Glueful\Validation\Validator($data, $rules);
-
-        if (!$validator->passes()) {
-            Response::error('Validation failed', 422, [
-                'errors' => $validator->errors()
-            ])->send();
-            exit;
-        }
-
-        return $validator->validated();
+        return $this->created($task);
     }
 }
 ```
 
-Create task controller:
+This example intentionally uses `BaseController::getRequestData()` and `BaseController::validateRequest()` because they are available in the current framework and match the starter app model.
 
-`app/Controllers/TaskController.php`:
+## Register the Routes
 
-```php
-<?php
-
-namespace App\Controllers;
-
-use Glueful\Http\Request;
-use Glueful\Http\Response;
-
-class TaskController
-{
-    public function index(Request $request)
-    {
-        $authUser = app(Glueful\Auth\AuthenticationManager::class)->user();
-        $userId = $authUser?->id ?? null;
-        $tasks = db()->from('tasks')
-            ->where('user_id', $userId)
-            ->orderBy('created_at', 'DESC')
-            ->get();
-
-        $mapped = array_map(fn($task) => [
-            'id' => $task['uuid'] ?? null,
-            'title' => $task['title'] ?? null,
-            'description' => $task['description'] ?? null,
-            'status' => $task['status'] ?? null,
-            'due_date' => $task['due_date'] ?? null,
-            'created_at' => $task['created_at'] ?? null,
-        ], $tasks ?? []);
-
-        return Response::success([
-            'tasks' => $mapped,
-        ]);
-    }
-
-    public function store(Request $request)
-    {
-        $validated = $this->validate($request->all(), [
-            'title' => 'required|string|min:3|max:255',
-            'description' => 'nullable|string',
-            'status' => 'nullable|in:pending,in_progress,completed',
-            'due_date' => 'nullable|date',
-        ]);
-
-        $authUser = app(Glueful\Auth\AuthenticationManager::class)->user();
-        $taskData = [
-            'uuid' => Utils::generateNanoID(12),
-            'user_id' => $authUser?->id,
-            'title' => $validated['title'],
-            'description' => $validated['description'] ?? null,
-            'status' => $validated['status'] ?? 'pending',
-            'due_date' => $validated['due_date'] ?? null,
-        ];
-        db()->from('tasks')->insert($taskData);
-        $task = db()->from('tasks')->where('uuid', $taskData['uuid'])->limit(1)->get()[0] ?? null;
-
-        return Response::created([
-            'task' => [
-                'id' => $task['uuid'],
-                'title' => $task['title'],
-                'description' => $task['description'],
-                'status' => $task['status'],
-                'due_date' => $task['due_date'],
-            ],
-        ]);
-    }
-
-    public function show(Request $request, $uuid)
-    {
-        $authUser = app(Glueful\Auth\AuthenticationManager::class)->user();
-        $task = db()->from('tasks')
-            ->where('uuid', $uuid)
-            ->where('user_id', $authUser?->id)
-            ->limit(1)
-            ->get()[0] ?? null;
-
-        if (!$task) {
-            return Response::error('Task not found', 404);
-        }
-
-        return Response::success([
-            'task' => [
-                'id' => $task['uuid'],
-                'title' => $task['title'],
-                'description' => $task['description'],
-                'status' => $task['status'],
-                'due_date' => $task['due_date'],
-                'created_at' => $task['created_at'],
-            ],
-        ]);
-    }
-
-    public function update(Request $request, $uuid)
-    {
-        $authUser = app(Glueful\Auth\AuthenticationManager::class)->user();
-        $task = db()->from('tasks')
-            ->where('uuid', $uuid)
-            ->where('user_id', $authUser?->id)
-            ->limit(1)
-            ->get()[0] ?? null;
-
-        if (!$task) {
-            return Response::error('Task not found', 404);
-        }
-
-        $validated = $this->validate($request->all(), [
-            'title' => 'sometimes|required|string|min:3|max:255',
-            'description' => 'nullable|string',
-            'status' => 'sometimes|in:pending,in_progress,completed',
-            'due_date' => 'nullable|date',
-        ]);
-
-        db()->from('tasks')
-            ->where('id', $task['id'])
-            ->update($validated);
-
-        $updated = db()->from('tasks')->where('id', $task['id'])->limit(1)->get()[0] ?? null;
-
-        return Response::success([
-            'task' => [
-                'id' => $updated['uuid'],
-                'title' => $updated['title'],
-                'description' => $updated['description'],
-                'status' => $updated['status'],
-                'due_date' => $updated['due_date'],
-            ],
-        ]);
-    }
-
-    public function destroy(Request $request, $uuid)
-    {
-        $authUser = app(Glueful\Auth\AuthenticationManager::class)->user();
-        $task = db()->from('tasks')
-            ->where('uuid', $uuid)
-            ->where('user_id', $authUser?->id)
-            ->limit(1)
-            ->get()[0] ?? null;
-
-        if (!$task) {
-            return Response::error('Task not found', 404);
-        }
-
-    db()->from('tasks')->where('id', $task['id'])->delete();
-
-    return Response::noContent();
-    }
-
-    protected function validate(array $data, array $rules)
-    {
-        $validator = new \Glueful\Validation\Validator($data, $rules);
-
-        if (!$validator->passes()) {
-            Response::error('Validation failed', 422, [
-                'errors' => $validator->errors()
-            ])->send();
-            exit;
-        }
-
-        return $validator->validated();
-    }
-}
-```
-
-## Step 4: Define Routes
-
-Edit `routes/api.php`:
+Update `routes/api.php`:
 
 ```php
 <?php
 
-use App\Controllers\AuthController;
+use Glueful\Routing\Router;
 use App\Controllers\TaskController;
+use App\Controllers\WelcomeController;
 
-// Public routes
-$router->post('/auth/register', [AuthController::class, 'register']);
-$router->post('/auth/login', [AuthController::class, 'login']);
+$router->group(['prefix' => 'v1'], function (Router $router) {
+    $router->get('/status', [WelcomeController::class, 'status']);
 
-// Protected routes (require authentication)
-$router->group(['middleware' => 'auth'], function ($router) {
-    // Task management
     $router->get('/tasks', [TaskController::class, 'index']);
     $router->post('/tasks', [TaskController::class, 'store']);
-    $router->get('/tasks/{uuid}', [TaskController::class, 'show']);
-    $router->put('/tasks/{uuid}', [TaskController::class, 'update']);
-    $router->delete('/tasks/{uuid}', [TaskController::class, 'destroy']);
 });
+
+$router->get('/welcome', [WelcomeController::class, 'index']);
 ```
 
-## Step 5: Test Your API
-
-Start the development server:
+## Start the Server
 
 ```bash
 php glueful serve
 ```
 
-### Register a user:
+## Test the API
+
+Create a task:
 
 ```bash
-curl -X POST http://localhost:8000/api/auth/register \
+curl -X POST http://127.0.0.1:8080/v1/tasks \
   -H "Content-Type: application/json" \
-  -d '{
-    "name": "John Doe",
-    "email": "john@example.com",
-    "password": "password123"
-  }'
+  -d '{"title":"Ship docs"}'
 ```
 
-Response:
-```json
-{
-  "success": true,
-  "data": {
-    "user": {
-      "id": "abc123",
-      "name": "John Doe",
-      "email": "john@example.com"
-    },
-    "token": "eyJ0eXAiOiJKV1QiLCJhbGc..."
-  }
-}
-```
-
-### Create a task:
+List tasks:
 
 ```bash
-curl -X POST http://localhost:8000/api/tasks \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
-  -d '{
-    "title": "Complete documentation",
-    "description": "Finish writing API docs",
-    "status": "in_progress",
-    "due_date": "2024-12-31"
-  }'
+curl http://127.0.0.1:8080/v1/tasks
 ```
 
-### Get all tasks:
+## What To Build Next
 
-```bash
-curl http://localhost:8000/api/tasks \
-  -H "Authorization: Bearer YOUR_TOKEN_HERE"
-```
+Once this flow is clear, move on to:
 
-### Update a task:
-
-```bash
-curl -X PUT http://localhost:8000/api/tasks/abc123 \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
-  -d '{
-    "status": "completed"
-  }'
-```
-
-### Delete a task:
-
-```bash
-curl -X DELETE http://localhost:8000/api/tasks/abc123 \
-  -H "Authorization: Bearer YOUR_TOKEN_HERE"
-```
-
-## What You Built
-
-✅ Complete REST API with authentication
-✅ Database schema with migrations
-✅ Input validation
-✅ Error handling
-✅ JWT authentication
-✅ CRUD operations
-
-## Next Steps
-
-- [Validation](../essentials/validation) - Advanced validation rules
-- [Authentication](../essentials/authentication) - Auth customization
-- [Testing](../advanced/testing) - Write API tests
-- [Deployment](../deployment/production) - Deploy to production
-
-## Full API Reference
-
-### Authentication Endpoints
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/auth/register` | Register new user |
-| POST | `/auth/login` | Login user |
-
-### Task Endpoints
-
-| Method | Endpoint | Auth | Description |
-|--------|----------|------|-------------|
-| GET | `/tasks` | ✓ | List all tasks |
-| POST | `/tasks` | ✓ | Create task |
-| GET | `/tasks/{id}` | ✓ | Get task |
-| PUT | `/tasks/{id}` | ✓ | Update task |
-| DELETE | `/tasks/{id}` | ✓ | Delete task |
-
-## Common Issues
-
-**Database connection error?**
-- Check `.env` database credentials
-- Ensure database exists
-- Run `php glueful migrate:run`
-
-**401 Unauthorized?**
-- Include `Authorization: Bearer TOKEN` header
-- Check token hasn't expired
-- Verify JWT_SECRET in `.env`
-
-**Validation errors?**
-- Check request payload matches validation rules
-- Ensure Content-Type is `application/json`
+- database-backed endpoints with [Database](/essentials/database)
+- route organization with [Routing](/essentials/routing)
+- validation patterns with [Validation](/essentials/validation)

--- a/content/2.essentials/1.routing.md
+++ b/content/2.essentials/1.routing.md
@@ -1,21 +1,21 @@
 ---
 title: Routing
-description: Map URLs to controllers and handlers
+description: Define routes with closures, controllers, groups, and attributes
 ---
 
-Routes define how your application responds to HTTP requests. Glueful provides a fast, intuitive routing system with O(1) static lookups and flexible middleware support.
+Glueful’s router supports explicit route files, route groups, middleware, named routes, and PHP attributes.
+
+Most applications start with `routes/api.php` in `glueful/api-skeleton`.
 
 ## Basic Routes
-
-Define routes in `routes/api.php`:
 
 ```php
 use Glueful\Http\Response;
 
-// Simple closure
-$router->get('/hello', fn() => new Response(['message' => 'Hello World']));
+$router->get('/welcome', function () {
+    return Response::success(['message' => 'Welcome']);
+});
 
-// Controller method
 $router->get('/users', [UserController::class, 'index']);
 $router->post('/users', [UserController::class, 'store']);
 ```
@@ -23,294 +23,146 @@ $router->post('/users', [UserController::class, 'store']);
 ## HTTP Methods
 
 ```php
-$router->get('/users', ...);      // GET
-$router->post('/users', ...);     // POST
-$router->put('/users/{id}', ...); // PUT
-$router->delete('/users/{id}', ...); // DELETE
-$router->head('/status', ...);    // HEAD
+$router->get('/users', ...);
+$router->post('/users', ...);
+$router->put('/users/{id}', ...);
+$router->delete('/users/{id}', ...);
+$router->head('/status', ...);
 ```
 
 ## Route Parameters
 
-### Basic Parameters
-
 ```php
 $router->get('/users/{id}', function (int $id) {
-    return Response::success(['user_id' => $id]);
-});
-```
-
-### Multiple Parameters
-
-```php
-$router->get('/posts/{year}/{month}/{slug}', function ($year, $month, $slug) {
-    // Access parameters by position or name
+    return Response::success(['id' => $id]);
 });
 ```
 
 ### Parameter Constraints
 
-Validate parameters with regex patterns:
-
 ```php
-// Numeric ID only
 $router->get('/users/{id}', [UserController::class, 'show'])
     ->where('id', '\d+');
 
-// Multiple constraints
 $router->get('/posts/{year}/{month}', [PostController::class, 'index'])
     ->where([
         'year' => '\d{4}',
-        'month' => '\d{2}'
+        'month' => '\d{2}',
     ]);
-
-// Slug pattern
-$router->get('/blog/{slug}', [BlogController::class, 'show'])
-    ->where('slug', '[a-z0-9-]+');
 ```
 
 ## Route Groups
 
-Share prefixes and middleware across multiple routes:
+Groups are the normal way to organize versioned APIs:
 
 ```php
-$router->group(['prefix' => '/api/v1'], function ($router) {
+use Glueful\Routing\Router;
+
+$router->group(['prefix' => 'v1'], function (Router $router) {
     $router->get('/users', [UserController::class, 'index']);
-    $router->get('/posts', [PostController::class, 'index']);
+    $router->post('/users', [UserController::class, 'store']);
 });
-// Creates: /api/v1/users, /api/v1/posts
 ```
 
-### Group with Middleware
+That produces:
+
+- `GET /v1/users`
+- `POST /v1/users`
+
+### Group Middleware
 
 ```php
-$router->group(['prefix' => '/admin', 'middleware' => ['auth', 'admin']], function ($router) {
+$router->group([
+    'prefix' => 'v1/admin',
+    'middleware' => ['auth']
+], function (Router $router) {
     $router->get('/dashboard', [AdminController::class, 'dashboard']);
-    $router->get('/users', [AdminController::class, 'users']);
 });
 ```
 
-### Nested Groups
+## Route Middleware
 
 ```php
-$router->group(['prefix' => '/api'], function ($router) {
-    $router->group(['prefix' => '/v1', 'middleware' => ['auth']], function ($router) {
-        $router->get('/profile', [ProfileController::class, 'show']);
-    });
-});
-// Creates: /api/v1/profile with auth middleware
-```
-
-## Middleware
-
-### Route-Level Middleware
-
-```php
-$router->get('/dashboard', [DashboardController::class, 'index'])
+$router->get('/profile', [ProfileController::class, 'show'])
     ->middleware('auth');
 
-// Multiple middleware
-$router->get('/admin', [AdminController::class, 'index'])
-    ->middleware(['auth', 'admin']);
-
-// Parameterized middleware
-$router->post('/api/upload', [UploadController::class, 'store'])
-    ->middleware('rate_limit:10,60'); // 10 requests per 60 seconds
+$router->post('/upload', [UploadController::class, 'store'])
+    ->middleware(['auth', 'rate_limit:10,60']);
 ```
 
-### Available Middleware
+Common middleware you will see in the framework:
 
-| Middleware | Purpose | Parameters |
-|------------|---------|------------|
-| `auth` | JWT authentication | None |
-| `cors` | CORS headers | None |
-| `csrf` | CSRF protection | None |
-| `rate_limit` | Rate limiting | `maxAttempts,windowSeconds` |
-
-## Dependency Injection
-
-Auto-inject services into route handlers:
-
-```php
-use Psr\Log\LoggerInterface;
-
-$router->get('/users/{id}', function (int $id, UserService $service, LoggerInterface $logger) {
-    $logger->info('Fetching user', ['id' => $id]);
-    return Response::success($service->find($id));
-});
-```
+- `auth`
+- `csrf`
+- `rate_limit:attempts,window`
 
 ## Named Routes
 
-Name routes for easy URL generation:
+Routes can be named:
 
 ```php
-$router->get('/users/{id}/profile', [ProfileController::class, 'show'])
-    ->name('user.profile');
-
-// Generate URL
-$url = route('user.profile', ['id' => 123]); // /users/123/profile
+$route = $router->get('/users/{id}', [UserController::class, 'show'])
+    ->where('id', '\d+')
+    ->name('users.show');
 ```
 
-## Route Attributes (PHP 8+)
-
-Define routes directly in controllers using attributes:
+To generate a URL, use the route object:
 
 ```php
-use Glueful\Http\Routing\Attributes\Route;
-
-class UserController
-{
-    #[Route('GET', '/users')]
-    public function index() {
-        // ...
-    }
-
-    #[Route('GET', '/users/{id}', where: ['id' => '\d+'])]
-    public function show(int $id) {
-        // ...
-    }
-
-    #[Route('POST', '/users', middleware: ['auth'])]
-    public function store() {
-        // ...
-    }
-}
+$url = $route->generateUrl(['id' => 123]);
+// /users/123
 ```
 
 ## Controller Resolution
 
-When you use the array callable form `[Controller::class, 'method']`, the router resolves the controller via the DI container and then calls the method. This enables constructor injection and consistent lifecycle handling.
+When you register `[Controller::class, 'method']`, the router resolves the controller through the container. That means constructor injection works as long as the controller is container-resolvable.
 
-- Requirement: Your controller class must be container‑resolvable (registered or autowire‑able).
-- Recommended: Register app controllers in an app service provider so they can be auto‑wired.
+In the API skeleton, app providers are enabled through `config/serviceproviders.php` and implemented in `app/Providers`.
 
-Example provider (App\Providers\AppServiceProvider):
+## Attribute Routing
+
+Glueful also supports attributes.
+
+Class-level prefix:
 
 ```php
-<?php
-namespace App\Providers;
+use Glueful\Routing\Attributes\Controller;
+use Glueful\Routing\Attributes\Get;
+use Glueful\Http\Response;
 
-final class AppServiceProvider
+#[Controller(prefix: '/v1/users')]
+class UserController
 {
-    // Provider discovery loads this static method to register services
-    public static function services(): array
+    #[Get('/{id}', where: ['id' => '\d+'])]
+    public function show(int $id): Response
     {
-        return [
-            // Autowire controllers so [Controller::class, 'method'] works
-            \App\Controllers\WelcomeController::class => [
-                'autowire' => true,
-                'shared' => true,
-            ],
-        ];
+        return Response::success(['id' => $id]);
     }
 }
 ```
 
-Enable the provider in `config/serviceproviders.php`:
+Generic route attribute:
 
 ```php
-return [
-    'enabled' => [
-        App\Providers\AppServiceProvider::class,
-    ],
-];
+use Glueful\Routing\Attributes\Route;
+
+class HealthController
+{
+    #[Route('/healthz', methods: 'GET', name: 'healthz')]
+    public function index(): Response
+    {
+        return Response::success(['ok' => true]);
+    }
+}
 ```
 
-If you don’t need DI for a route, you can also use a closure and manually instantiate the controller:
+## Route Cache Commands
 
-```php
-use Symfony\Component\HttpFoundation\Request;
-
-$router->get('/index', function (Request $request) {
-    return (new WelcomeController())->index($request);
-});
-```
-
-## Performance Tips
-
-### Route Caching
-
-Cache routes in production for faster lookup:
+The currently documented route-cache commands are:
 
 ```bash
-# Cache routes
-php glueful route:cache
-
-# Clear cache
-php glueful route:clear
+php glueful route:cache:status
+php glueful route:cache:clear
 ```
 
-### Avoid Dynamic Routes
-
-```php
-// ❌ Avoid - creates many routes
-for ($i = 1; $i <= 100; $i++) {
-    $router->get("/page{$i}", ...);
-}
-
-// ✅ Better - use parameters
-$router->get('/page/{number}', ...)
-    ->where('number', '\d+');
-```
-
-## Common Patterns
-
-### RESTful Resources
-
-```php
-// Full CRUD for a resource
-$router->get('/posts', [PostController::class, 'index']);      // List
-$router->post('/posts', [PostController::class, 'store']);     // Create
-$router->get('/posts/{id}', [PostController::class, 'show']);  // Read
-$router->put('/posts/{id}', [PostController::class, 'update']); // Update
-$router->delete('/posts/{id}', [PostController::class, 'destroy']); // Delete
-```
-
-### API Versioning
-
-```php
-$router->group(['prefix' => '/api/v1'], function ($router) {
-    require __DIR__ . '/api/v1.php';
-});
-
-$router->group(['prefix' => '/api/v2'], function ($router) {
-    require __DIR__ . '/api/v2.php';
-});
-```
-
-### Protected Routes
-
-```php
-// Public routes
-$router->post('/login', [AuthController::class, 'login']);
-$router->post('/register', [AuthController::class, 'register']);
-
-// Protected routes
-$router->group(['middleware' => ['auth']], function ($router) {
-    $router->get('/profile', [ProfileController::class, 'show']);
-    $router->put('/profile', [ProfileController::class, 'update']);
-    $router->delete('/account', [AccountController::class, 'delete']);
-});
-```
-
-## Troubleshooting
-
-**Route not found (404)?**
-- Check route definition spelling and parameters
-- Verify middleware isn't blocking the route
-- Clear route cache: `php glueful route:clear`
-
-**Parameter not passed to handler?**
-- Ensure parameter names match route definition
-- Check type hints match expected data
-
-**Middleware not executing?**
-- Verify middleware is registered in service provider
-- Check middleware order in groups
-
-## Next Steps
-
-- [Controllers](controllers) - Handle route logic
-- [Middleware](../advanced/middleware) - Custom request processing
-- [Requests & Responses](requests-responses) - Work with HTTP data
+Do not rely on a `route:cache` command unless it has been added to your installed framework version.

--- a/content/2.essentials/2.authentication.md
+++ b/content/2.essentials/2.authentication.md
@@ -56,8 +56,8 @@ Successful response shape (fields may vary depending on provider & configuration
     "message": "Login successful",
     "data": {
         "access_token": "<JWT>",
-        "refresh_token": "<refresh>
-        ","token_type": "Bearer",
+        "refresh_token": "<refresh>",
+        "token_type": "Bearer",
         "expires_in": 3600,
         "user": {
             "id": "user-uuid",
@@ -109,27 +109,20 @@ curl http://localhost:8000/api/profile \
 During a request protected by `auth` middleware, user data is attached to the request context and included in the login / token responses. Typical pattern:
 
 ```php
-use Glueful\Auth\AuthBootstrap;
+use Glueful\Controllers\BaseController;
+use Glueful\Http\Response;
 use Symfony\Component\HttpFoundation\Request;
 
-class ProfileController
+class ProfileController extends BaseController
 {
-    public function show(Request $request)
+    public function show(Request $request): Response
     {
-        // Using the auth manager to re-authenticate (idempotent)
-        $authManager = AuthBootstrap::getManager();
-        $user = $authManager->authenticate($request); // array|null
-
-        if (!$user) {
-            return Response::unauthorized('Not authenticated');
+        if ($this->currentUser === null) {
+            return $this->unauthorized('Not authenticated');
         }
 
-        return Response::success([
-            'user' => [
-                'id' => $user['uuid'] ?? null,
-                'email' => $user['email'] ?? null,
-                'username' => $user['username'] ?? null,
-            ]
+        return $this->success([
+            'user' => $this->currentUser->toArray(),
         ]);
     }
 }
@@ -141,14 +134,23 @@ Registration is application-specific. Minimal illustrative flow:
 
 ```php
 use Glueful\Auth\TokenManager;
+use Glueful\Controllers\BaseController;
 use Glueful\Helpers\Utils;
+use Symfony\Component\HttpFoundation\Request;
 
-class RegistrationController
+class RegistrationController extends BaseController
 {
-    public function register(Request $request)
+    public function register(Request $request): Response
     {
-        $data = RequestHelper::getRequestData();
-        // (Validate using your validator service)
+        $data = $this->getRequestData();
+
+        if ($error = $this->validateRequest($data, [
+            'email' => 'required|email|max:255',
+            'password' => 'required|max:255',
+            'username' => 'max:100',
+        ])) {
+            return $error;
+        }
 
         $userRecord = [
             'uuid' => Utils::generateNanoID(),
@@ -158,18 +160,19 @@ class RegistrationController
             'created_at' => date('Y-m-d H:i:s')
         ];
 
-        db()->table('users')->insert($userRecord);
+        $this->db->table('users')->insert($userRecord);
 
         // Don't return password
         unset($userRecord['password']);
 
-        $tokens = TokenManager::generateTokenPair([
+        $tokenManager = app($this->getContext(), TokenManager::class);
+        $tokens = $tokenManager->generateTokenPair([
             'uuid' => $userRecord['uuid'],
             'email' => $userRecord['email'],
             'username' => $userRecord['username']
         ]);
 
-        return Response::created([
+        return $this->created([
             'user' => $userRecord,
             ...$tokens
         ]);
@@ -279,16 +282,23 @@ If your router does not yet parse colon parameters for middleware you can instea
 Implements the same `RouteMiddleware` interface pattern as core middleware:
 
 ```php
-use Glueful\Auth\AuthBootstrap;
+use Glueful\Auth\AuthenticationManager;
+use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Routing\RouteMiddleware;
+use Glueful\Http\Response;
 use Symfony\Component\HttpFoundation\Request;
 
 class RequireRolesMiddleware implements RouteMiddleware
 {
+    public function __construct(
+        private ApplicationContext $context
+    ) {}
+
     public function handle(Request $request, callable $next, ...$requiredRoles): mixed
     {
-        $authManager = AuthBootstrap::getManager();
+        $authManager = app($this->context, AuthenticationManager::class);
         $user = $authManager->authenticate($request);
+
         if (!$user) {
             return Response::unauthorized('Authentication required');
         }
@@ -317,15 +327,27 @@ For complex authorization (resource-level permissions, dynamic policies), prefer
 Pattern example:
 
 ```php
-$post = db()->table('posts')
-    ->where(['uuid' => $postUuid])
-    ->get()[0] ?? null;
-if (!$post) return Response::notFound('Post not found');
-if (($post['user_uuid'] ?? null) !== ($user['uuid'] ?? null)) {
-    return Response::forbidden('You can only edit your own posts');
+if ($this->currentUser === null) {
+    return $this->unauthorized();
 }
-db()->table('posts')->where(['uuid' => $postUuid])->update($payload);
-return Response::success(null, 'Post updated');
+
+$post = $this->db->table('posts')
+    ->where(['uuid' => $postUuid])
+    ->first();
+
+if ($post === null) {
+    return $this->notFound('Post not found');
+}
+
+if (($post['user_uuid'] ?? null) !== $this->currentUser->uuid) {
+    return $this->forbidden('You can only edit your own posts');
+}
+
+$this->db->table('posts')
+    ->where(['uuid' => $postUuid])
+    ->update($payload);
+
+return $this->success(null, 'Post updated');
 ```
 
 ## Password Reset
@@ -344,18 +366,20 @@ The controller handles validation, session consistency, and email dispatch. Impl
 ```php
 public function profile()
 {
-    $user = $this->auth->user();
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
 
     // Load related data
-    $userData = db()->table('users')
-        ->where(['uuid' => $user['uuid']])
-        ->get()[0] ?? null;
+    $userData = $this->db->table('users')
+        ->where(['uuid' => $this->currentUser->uuid])
+        ->first();
 
-    $postCount = db()->table('posts')
-        ->where(['user_uuid' => $user['uuid']])
+    $postCount = $this->db->table('posts')
+        ->where(['user_uuid' => $this->currentUser->uuid])
         ->count();
 
-    return Response::success([
+    return $this->success([
         'user' => $userData,
         'stats' => [
             'posts_count' => $postCount
@@ -369,17 +393,25 @@ public function profile()
 ```php
 public function updateProfile()
 {
-    $validated = $this->validate($this->request->input(), [
-        'name' => 'nullable|min:2',
-        'bio' => 'nullable|max:500',
-        'website' => 'nullable|url'
-    ]);
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
 
-    db()->table('users')
-        ->where(['uuid' => $user['uuid']])
-        ->update($validated);
+    $data = $this->getRequestData();
 
-    return Response::success(null, 'Profile updated');
+    if ($error = $this->validateRequest($data, [
+        'name' => 'max:100',
+        'bio' => 'max:500',
+        'website' => 'max:255'
+    ])) {
+        return $error;
+    }
+
+    $this->db->table('users')
+        ->where('uuid', $this->currentUser->uuid)
+        ->update($data);
+
+    return $this->success(null, 'Profile updated');
 }
 ```
 
@@ -388,28 +420,36 @@ public function updateProfile()
 ```php
 public function changePassword()
 {
-    $data = $this->validate($this->request->input(), [
-        'current_password' => 'required',
-        'new_password' => 'required|min:8|confirmed'
-    ]);
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
 
-    $user = db()->table('users')
-        ->where(['uuid' => $current['uuid']])
-        ->get()[0] ?? null;
+    $data = $this->getRequestData();
+
+    if ($error = $this->validateRequest($data, [
+        'current_password' => 'required|max:255',
+        'new_password' => 'required|max:255'
+    ])) {
+        return $error;
+    }
+
+    $user = $this->db->table('users')
+        ->where('uuid', $this->currentUser->uuid)
+        ->first();
 
     // Verify current password
-    if (!password_verify($data['current_password'], $user->password)) {
+    if (!$user || !password_verify($data['current_password'], $user['password'])) {
         return Response::error('Current password is incorrect', 400);
     }
 
     // Update password
-    db()->table('users')
-        ->where(['uuid' => $user['uuid']])
+    $this->db->table('users')
+        ->where(['uuid' => $this->currentUser->uuid])
         ->update([
             'password' => password_hash($data['new_password'], PASSWORD_DEFAULT)
         ]);
 
-    return Response::success(null, 'Password changed successfully');
+    return $this->success(null, 'Password changed successfully');
 }
 ```
 
@@ -419,10 +459,10 @@ public function changePassword()
 
 ```php
 // ✅ Always hash passwords
-$user->password = password_hash($password, PASSWORD_DEFAULT);
+$userRecord['password'] = password_hash($password, PASSWORD_DEFAULT);
 
 // ❌ Never store plain text
-$user->password = $password;
+$userRecord['password'] = $password;
 ```
 
 ### Use HTTPS in Production
@@ -435,9 +475,20 @@ $user->password = $password;
 ### Validate Strong Passwords
 
 ```php
-$this->validate($data, [
+use Glueful\Validation\Support\RuleParser;
+use Glueful\Validation\Validator;
+use Glueful\Validation\ValidationException;
+
+$rules = (new RuleParser())->parse([
     'password' => 'required|min:8|regex:/[a-z]/|regex:/[A-Z]/|regex:/[0-9]/'
 ]);
+
+$validator = new Validator($rules);
+$errors = $validator->validate($data);
+
+if ($errors !== []) {
+    throw new ValidationException($errors);
+}
 ```
 
 ### Rate Limit Auth Endpoints

--- a/content/2.essentials/3.requests-responses.md
+++ b/content/2.essentials/3.requests-responses.md
@@ -1,151 +1,94 @@
 ---
 title: Requests & Responses
-description: Handle HTTP input and output
+description: Read request data and return consistent JSON responses
 ---
 
-Learn how to work with HTTP requests and return properly formatted JSON responses.
+Glueful controllers work with Symfony `Request` objects and Glueful `Response` helpers.
 
-## Request Basics
+## Reading Request Data
 
-Access the current Symfony Request instance in controllers (injected as `$this->request`):
+In controllers that extend `BaseController`, use the helper methods that already exist:
 
 ```php
-public function store()
+use Symfony\Component\HttpFoundation\Request;
+
+public function store(Request $request)
 {
-    // All JSON/form body input
-    $data = $this->request->request->all();
+    $data = $this->getRequestData();
 
-    // Specific fields (null if missing)
-    $email = $this->request->request->get('email');
-
-    // With default value
-    $name = $this->request->request->get('name', 'Guest');
+    $email = $request->request->get('email');
+    $page = (int) $request->query->get('page', 1);
+    $token = $request->headers->get('Authorization');
 }
 ```
 
-## Getting Input Data
+### JSON Requests
 
-### JSON Body
+`BaseController::getRequestData()` detects JSON requests and returns a parsed array:
 
 ```php
-// POST /api/users
-// Body: {"name": "John", "email": "john@example.com"}
-
-public function store()
+public function store(Request $request)
 {
-    $name = $this->request->request->get('name');
-    $email = $this->request->request->get('email');
+    $data = $this->getRequestData();
 
-    // Or get all (JSON auto parsed)
-    $data = $this->request->request->all();
-    // ['name' => 'John', 'email' => 'john@example.com']
+    return $this->success([
+        'received' => $data,
+    ]);
 }
-```
-
-### Query Parameters
-
-```php
-// GET /api/users?page=2&limit=10
-
-public function index()
-{
-    $page = (int) $this->request->query->get('page', 1);
-    $limit = (int) $this->request->query->get('limit', 20);
-}
-```
-
-### Route Parameters
-
-```php
-// Route: /users/{id}/posts/{postId}
-
-public function show(string $id, string $postId)
-{
-    // Parameters injected automatically
-}
-```
-
-### Headers
-
-```php
-$token = $this->request->headers->get('Authorization');
-$contentType = $this->request->headers->get('Content-Type');
 ```
 
 ### Files
 
 ```php
-public function upload()
+public function upload(Request $request)
 {
-    $file = $this->request->files->get('avatar');
+    $file = $request->files->get('avatar');
 
-    if ($file) {
-        $path = $file->move('/uploads', $file->getClientOriginalName());
+    if ($file === null) {
+        return Response::validation([
+            'avatar' => ['Avatar is required.'],
+        ]);
     }
+
+    return Response::success([
+        'filename' => $file->getClientOriginalName(),
+    ]);
 }
 ```
 
 ## Response Helpers
 
-Glueful provides consistent JSON response helpers:
+Glueful’s `Response` class standardizes JSON output.
 
-### Success Responses
+### Success
 
 ```php
 use Glueful\Http\Response;
 
-// Basic success (default message = "Success")
 return Response::success($data);
-// {"success": true, "message": "Success", "data": {...}}
-
-// Custom message
-return Response::success($users, 'Users retrieved');
-// {"success": true, "message": "Users retrieved", "data": [...]} 
-
-// Created (201)
+return Response::success($data, 'Users retrieved');
 return Response::created($user);
-// {"success": true, "message": "Created successfully", "data": {...}}
-
-// No content (204)
 return Response::noContent();
-// HTTP 204 empty body
 ```
 
-### Error Responses
+### Errors
 
 ```php
-// Not found (404)
 return Response::notFound('User not found');
-// {
-//   "success": false,
-//   "message": "User not found",
-//   "error": {
-//     "code": 404,
-//     "timestamp": "2024-01-15T10:30:00Z",
-//     "request_id": "req_ab12cd34ef",
-//     "details": { ... } // only when provided
-//   }
-// }
-
-// Unauthorized (401)
 return Response::unauthorized('Invalid token');
-
-// Forbidden (403)
 return Response::forbidden('Access denied');
-
-// Validation error (422) - details show field errors
-return Response::validation(['email' => 'Email is required']);
-
-// Custom error with extra context
-return Response::error('Something went wrong', 500, ['operation' => 'import']);
+return Response::validation([
+    'email' => ['Email is required.'],
+]);
+return Response::error('Something went wrong', 500);
 ```
 
 ### Pagination
 
 ```php
-public function index()
+public function index(Request $request): Response
 {
-    $page = (int) $this->request->query->get('page', 1);
+    $page = (int) $request->query->get('page', 1);
     $perPage = 20;
 
     $users = $this->db->table('users')
@@ -157,327 +100,25 @@ public function index()
 
     return Response::paginated($users, $total, $page, $perPage);
 }
-
-// Returns (flattened pagination + default message):
-// {
-//   "success": true,
-//   "message": "Data retrieved successfully",
-//   "data": [...],
-//   "current_page": 1,
-//   "per_page": 20,
-//   "total": 100,
-//   "total_pages": 5,
-//   "has_next_page": true,
-//   "has_previous_page": false
-// }
 ```
 
-## Complete Examples
+## Recommended Pattern
 
-### Simple CRUD
-
-```php
-class TaskController
-{
-    public function index()
-    {
-        $tasks = $this->db->table('tasks')->get();
-        return Response::success($tasks);
-    }
-
-    public function store()
-    {
-    $data = $this->request->request->all();
-
-        $task = $this->db->table('tasks')->insert([
-            'title' => $data['title'],
-            'description' => $data['description'] ?? null,
-            'completed' => false
-        ]);
-
-        return Response::created($task);
-    }
-
-    public function show(string $id)
-    {
-        $task = $this->db->table('tasks')
-            ->where('uuid', $id)
-            ->first();
-
-        if (!$task) {
-            return Response::notFound('Task not found');
-        }
-
-        return Response::success($task);
-    }
-
-    public function update(string $id)
-    {
-    $data = $this->request->request->all();
-
-        $updated = $this->db->table('tasks')
-            ->where('uuid', $id)
-            ->update($data);
-
-        if (!$updated) {
-            return Response::notFound('Task not found');
-        }
-
-        return Response::success(null, 'Task updated');
-    }
-
-    public function destroy(string $id)
-    {
-        $deleted = $this->db->table('tasks')
-            ->where('uuid', $id)
-            ->delete();
-
-        if (!$deleted) {
-            return Response::notFound('Task not found');
-        }
-
-        return Response::noContent();
-    }
-}
-```
-
-### With Validation
+For most controllers in the API skeleton:
 
 ```php
-public function store()
+public function store(Request $request): Response
 {
-    $data = $this->request->request->all();
+    $data = $this->getRequestData();
 
-    // Validate
-    $validated = $this->validate($data, [
-        'title' => 'required|min:3',
-        'email' => 'required|email'
+    if ($error = $this->validateRequest($data, [
+        'title' => 'required|max:255',
+    ])) {
+        return $error;
+    }
+
+    return $this->created([
+        'title' => $data['title'],
     ]);
-
-    // Validation passed
-    $task = $this->db->table('tasks')->insert($validated);
-
-    return Response::created($task);
 }
 ```
-
-### Search & Filter
-
-```php
-public function index()
-{
-    $query = $this->db->table('products');
-
-    // Search
-    if ($search = $this->request->query->get('search')) {
-        $query->where('name', 'LIKE', "%{$search}%");
-    }
-
-    // Filter by category
-    if ($category = $this->request->query->get('category')) {
-        $query->where('category', $category);
-    }
-
-    // Sort
-    $sortBy = $this->request->query->get('sort', 'created_at');
-    $sortOrder = $this->request->query->get('order', 'desc');
-    $query->orderBy($sortBy, $sortOrder);
-
-    // Paginate
-    $page = (int) $this->request->query->get('page', 1);
-    $perPage = 20;
-
-    $products = $query
-        ->limit($perPage)
-        ->offset(($page - 1) * $perPage)
-        ->get();
-
-    $total = $query->count();
-
-    return Response::paginated($products, $total, $page, $perPage);
-}
-```
-
-## Request Methods
-
-### Checking Request Method
-
-```php
-if ($this->request->isMethod('POST')) {
-    // Handle POST
-}
-
-if ($this->request->isMethod('GET')) {
-    // Handle GET
-}
-```
-
-### Getting All Headers
-
-```php
-$headers = $this->request->headers->all();
-```
-
-### Getting Client IP
-
-```php
-$ip = $this->request->getClientIp();
-```
-
-### Checking for AJAX
-
-```php
-if ($this->request->isXmlHttpRequest()) {
-    // AJAX request
-}
-```
-
-## Response Customization
-
-### Custom Status Code
-
-```php
-return Response::success($data)->setStatusCode(202);
-```
-
-### Custom Headers
-
-```php
-return Response::success($data)
-    ->header('X-Custom-Header', 'value')
-    ->header('X-Rate-Limit', '100');
-```
-
-### Download Response
-
-```php
-// Provide your own file bytes then mark as download
-$contents = file_get_contents('/path/to/file.pdf');
-return Response::success(['file' => base64_encode($contents)])
-    ->asDownload('file.pdf', 'application/pdf');
-```
-
-Or serve a real file (stream) with the helper:
-
-```php
-return response()->file('/path/to/file.pdf'); // inline disposition
-// For attachment: response()->file('/path/to/file.pdf', 'file.pdf', [], 'attachment');
-```
-
-### File Response
-
-```php
-return response()->file('/path/to/image.jpg');
-```
-
-## Common Patterns
-
-### API with Meta Data
-
-```php
-return Response::successWithMeta($users, [
-    'filters_applied' => ['status' => 'active'],
-    'generated_at' => date('c')
-]);
-
-// Returns:
-// {
-//   "success": true,
-//   "message": "Data retrieved successfully",
-//   "data": [...],
-//   "filters_applied": {"status":"active"},
-//   "generated_at": "2024-01-15T10:30:00Z"
-// }
-```
-
-### Error with Details
-
-```php
-return Response::error('Quota exceeded', 403, [
-    'plan' => 'free',
-    'limit' => 1000,
-    'current' => 1000,
-    'upgrade_url' => '/pricing'
-]);
-```
-
-### Conditional Response
-
-```php
-public function show(string $id)
-{
-    $user = $this->db->table('users')
-        ->where('uuid', $id)
-        ->first();
-
-    return $user
-        ? Response::success($user)
-        : Response::notFound('User not found');
-}
-```
-
-## Best Practices
-
-### Always Return JSON
-
-```php
-// ✅ Good
-return Response::success($data);
-
-// ❌ Avoid
-return $data; // Might not be properly formatted
-```
-
-### Use Appropriate Status Codes
-
-```php
-// Create → 201
-return Response::created($user);
-
-// Delete → 204
-return Response::noContent();
-
-// Not found → 404
-return Response::notFound();
-
-// Validation error → 422
-return Response::validation($errors);
-```
-
-### Include Error Context
-
-```php
-// ✅ Helpful
-return Response::notFound('Product #' . $id . ' not found');
-
-// ❌ Less helpful
-return Response::notFound();
-```
-
-## Troubleshooting
-
-**Empty request body?**
-- Check `Content-Type: application/json` header is set
-- Verify JSON is valid
-
-**Parameters not available?**
-- Route parameters must match method signature
-- Query parameters use `$this->request->query->get()`
-- Body parameters use `$this->request->request->all()` / `->get()`
-
-**Response not JSON?**
-- Always use `Response::` helpers
-- Check you're returning the Response object
-- Ensure JSON body has valid syntax
-
-**Need raw request data?**
-- Use `RequestHelper::getRequestData()` or controller's protected `getRequestData()`
-
-**Correlate errors?**
-- Use the `request_id` in error responses for tracing (logged automatically)
-
-## Next Steps
-
-- [Validation](validation) - Validate request data
-- [Controllers](controllers) - Organize request handling
-- [Database](database) - Query and store data

--- a/content/2.essentials/4.controllers.md
+++ b/content/2.essentials/4.controllers.md
@@ -1,565 +1,102 @@
 ---
 title: Controllers
-description: Organize request handling logic
+description: Organize request handling logic with BaseController
 ---
 
-Controllers handle HTTP requests and return responses. They organize your application logic and keep route files clean.
+In the API skeleton, application controllers live in `app/Controllers/` and usually extend `Glueful\Controllers\BaseController`.
 
-## Creating Controllers
-
-Controllers live in `app/Controllers/` and should extend `Glueful\Controllers\BaseController`.
+## Basic Controller
 
 ```php
 <?php
+
+declare(strict_types=1);
 
 namespace App\Controllers;
 
 use Glueful\Controllers\BaseController;
 use Glueful\Http\Response;
+use Symfony\Component\HttpFoundation\Request;
 
 class UserController extends BaseController
 {
-    public function index()
+    public function index(Request $request): Response
     {
         $users = $this->db->table('users')->get();
-        return Response::success($users);
+
+        return $this->success($users);
     }
 }
 ```
 
-## Basic Structure
+## What BaseController Gives You
 
-A typical controller (using the BaseController convenience response helpers like `$this->success()` and `$this->created()`):
+`BaseController` already includes:
+
+- `$this->db` for database access
+- `$this->request` for the current Symfony request
+- response helpers like `$this->success()` and `$this->created()`
+- request helpers like `$this->getRequestData()`
+- lightweight validation via `$this->validateRequest()`
+
+## Create / Update Example
 
 ```php
-<?php
-
-namespace App\Controllers;
-
-use Glueful\Controllers\BaseController;
-use Glueful\Http\Response;
-
 class TaskController extends BaseController
 {
-    // List all tasks
-    public function index()
+    public function store(Request $request): Response
     {
-    $tasks = $this->db->table('tasks')->get();
-    return $this->success($tasks);
-    }
+        $data = $this->getRequestData();
 
-    // Get single task
-    public function show(string $uuid)
-    {
-        $task = $this->db->table('tasks')
-            ->where('uuid', $uuid)
-            ->first();
-
-        if (!$task) {
-            return $this->notFound('Task not found');
-        }
-
-    return $this->success($task);
-    }
-
-    // Create task
-    public function store()
-    {
-    $data = $this->getRequestData();
-
-        // Basic validation (returns Response on failure or null if ok)
         if ($error = $this->validateRequest($data, [
             'title' => 'required|max:255',
-            'description' => 'max:1000'
+            'description' => 'max:1000',
         ])) {
-            return $error; // 422 validation error
+            return $error;
         }
 
-        $task = $this->db->table('tasks')->insert([
-            'uuid' => Utils::generateNanoID(),
+        $taskId = $this->db->table('tasks')->insert([
             'title' => $data['title'],
             'description' => $data['description'] ?? null,
         ]);
 
-    return $this->created($task);
-    }
-
-    // Update task
-    public function update(string $uuid)
-    {
-    $data = $this->getRequestData();
-
-        $this->db->table('tasks')
-            ->where('uuid', $uuid)
-            ->update($data);
-
-    return $this->success(null, 'Task updated');
-    }
-
-    // Delete task
-    public function destroy(string $uuid)
-    {
-        $this->db->table('tasks')
-            ->where('uuid', $uuid)
-            ->delete();
-
-    return Response::noContent();
+        return $this->created([
+            'id' => $taskId,
+            'title' => $data['title'],
+        ]);
     }
 }
 ```
 
-## Dependency Injection
+## Constructor Injection
 
-Inject services via constructor or method parameters:
+Controllers are resolved from the container, so constructor injection works:
 
 ```php
-<?php
-
-namespace App\Controllers;
-
-use App\Services\UserService;
-use Glueful\Controllers\BaseController;
-use Glueful\Http\Response;
 use Psr\Log\LoggerInterface;
 
 class UserController extends BaseController
 {
     public function __construct(
-        private UserService $users,
+        \Glueful\Bootstrap\ApplicationContext $context,
         private LoggerInterface $logger
-    ) {}
-
-    public function index()
-    {
-        $this->logger->info('Fetching users');
-    $users = $this->users->getAll();
-    return $this->success($users);
+    ) {
+        parent::__construct($context);
     }
 
-    // Method injection
-    public function show(string $uuid, UserService $users)
+    public function index(Request $request): Response
     {
-        $user = $this->db->table('users')->where('uuid', $uuid)->first();
-        return $this->success($user);
+        $this->logger->info('Listing users');
+
+        return $this->success($this->db->table('users')->get());
     }
 }
 ```
 
-## Built-in Properties
+If you override the constructor, call `parent::__construct($context)` so the base dependencies are initialized.
 
-Base controller provides helpful properties & helpers:
+## ResourceController
 
-```php
-class MyController extends BaseController
-{
-    public function example()
-    {
-        // Database connection
-        $this->db->table('users')->get();
+Glueful also ships a built-in `Glueful\Controllers\ResourceController` for generic CRUD-heavy cases. Use it when you want convention-driven resource endpoints quickly, but prefer explicit controllers first while you are learning the framework.
 
-        // Current request
-    $data = $this->getRequestData();
-    $email = $data['email'] ?? null; // or: $this->request->request->get('email')
-
-        // Cache
-        $this->cache->get('key');
-
-        // Logger
-        $this->logger->info('message');
-    }
-}
-```
-
-## ResourceController (Built‑in Generic CRUD)
-
-Glueful ships with a powerful `Glueful\Controllers\ResourceController` that provides generic, permission‑aware CRUD for any database table. It is intentionally conservative by default: most security features are opt‑in via protected boolean flags you can override or configure. Use it when you want to expose standard create/read/update/delete endpoints quickly without writing a bespoke controller.
-
-### Default Route Semantics
-
-You typically mount it once and let route parameters determine the table. (Exact route wiring may vary depending on your routing layer — below is a conceptual example):
-
-```
-GET    /resource/{resource}              -> get()        // list (paginated)
-GET    /resource/{resource}/{uuid}       -> getSingle()  // fetch one
-POST   /resource/{resource}              -> post()       // create
-PUT    /resource/{resource}/{uuid}       -> put()        // update
-DELETE /resource/{resource}/{uuid}       -> delete()     // delete
-```
-
-Parameter names used internally: `resource` for the table, `uuid` for the row identifier (the repository layer resolves underlying primary key logic).
-
-### High‑Level Flow Per Operation
-
-1. Resolve table from route param
-2. (Optional) Apply table access control (`applyTableAccessControl`)
-3. Enforce permission: tries table‑scoped permission first (e.g. `resource.posts.read`) then falls back to generic (`resource.read` / `resource.create` / `resource.update` / `resource.delete`)
-4. Apply rate limiting per (table, action)
-5. For reads: parse pagination & filtering, call repository (cached)
-6. For writes: enforce low‑risk behavior, hash password field if present, invalidate cache
-7. Apply optional ownership and field‑level permission filtering
-8. Return standardized response via `Response` helpers
-
-### Security & Feature Toggles
-
-These protected flags (all defined in `ResourceController`) can be overridden in a subclass or influenced by configuration (see `loadSecurityConfiguration()`):
-
-```php
-protected bool $enableTableAccessControl = false; // Restrict which tables are exposed
-protected bool $enableFieldPermissions   = false; // Hide or filter sensitive fields
-protected bool $enableBulkOperations     = false; // (Reserved) enable secure bulk ops
-protected bool $enableQueryRestrictions  = false; // Sanitize/whitelist query params
-protected bool $enableOwnershipValidation = true; // Enforce ownership on certain tables
-```
-
-Override the corresponding hook methods to implement behavior:
-
-```php
-protected function applyTableAccessControl(string $table): void {}
-protected function applyFieldPermissions($data, string $table, string $operation) { return $data; }
-protected function applyQueryRestrictions(array $queryParams, string $table): array { return $queryParams; }
-protected function applyOwnershipValidation(string $table, string $uuid, array $record): void {}
-```
-
-Ownership validation (enabled by default) currently checks tables like `profiles` and `blobs` for user‐scoped fields and escalates to admin permissions if mismatched.
-
-### Pagination & Filtering
-
-List requests (`get`) accept conventional query params:
-
-| Param      | Meaning                                | Default |
-|------------|----------------------------------------|---------|
-| page       | Page number (>=1)                      | 1       |
-| per_page   | Page size (capped at 100)              | 25      |
-| sort       | Column to sort by                      | id      |
-| order      | asc or desc                            | desc    |
-| fields     | Comma list of columns to select / *    | * (all) |
-| others     | Treated as equality filters            | —       |
-
-Filtering: any additional query parameter not in the reserved list (`page, per_page, sort, order, fields`) becomes an equality condition passed to the repository. If you enable query restrictions you can intercept & sanitize these in `applyQueryRestrictions` before conditions are built.
-
-### Caching Strategy
-
-Read paths use `cacheByPermission("resource:{table}:...", ...)` to create per‑permission scoped cache entries. After create/update/delete, `invalidateTableCache($table, $uuid?)` clears related table and item level tags (`repository:{table}`, `resource:{table}`, `resource:{table}:{uuid}`). This keeps stale data minimal without over‑invalidating.
-
-### Rate Limiting
-
-Every action calls `$this->rateLimitResource($table, $action, $limit, $windowSeconds)` with conservative defaults:
-
-| Action | Example Limit (per window) |
-|--------|----------------------------|
-| read (list / single) | 100 / 60s |
-| create | 50 / 60s |
-| update | 30 / 60s |
-| delete | 10 / 60s |
-
-Tweak by overriding method or subclassing and applying different limits.
-
-### Password Hashing Convenience
-
-If incoming create/update payload includes a `password` key it is automatically hashed using `PasswordHasher` before persistence.
-
-### Example: Extending with Field-Level Permissions
-
-```php
-use Glueful\Controllers\ResourceController;
-
-class SecureResourceController extends ResourceController
-{
-    protected bool $enableFieldPermissions = true;
-    protected bool $enableTableAccessControl = true;
-
-    protected function applyTableAccessControl(string $table): void
-    {
-        $allowed = ['posts', 'profiles'];
-        if (!in_array($table, $allowed, true)) {
-            $this->requirePermission('admin.resource.access');
-        }
-    }
-
-    protected function applyFieldPermissions($data, string $table, string $operation)
-    {
-        if ($table === 'profiles') {
-            // Hide internal columns
-            $filter = static function(array $row) {
-                unset($row['password_hash'], $row['secret_token']);
-                return $row;
-            };
-            if (isset($data['data']) && is_array($data['data'])) {
-                // Paginated shape: ['data' => [...], 'total' => ...]
-                $data['data'] = array_map($filter, $data['data']);
-                return $data;
-            }
-            if (is_array($data) && array_is_list($data)) {
-                return array_map($filter, $data);
-            }
-            if (is_array($data)) {
-                return $filter($data);
-            }
-        }
-        return $data;
-    }
-}
-```
-
-### When to Use vs. Custom Controller
-
-Because the framework already registers dynamic resource routes in `framework/routes/resource.php`, you can adopt `ResourceController` immediately—no manual route wiring required. Decide per table whether to rely on the generic layer or create a bespoke controller.
-
-Use `ResourceController` when:
-- You need fast CRUD exposure while still enforcing permissions & rate limits
-- Table shape maps cleanly to what the API should return
-- You benefit from automatic ownership validation & caching without customization
-- You want consistent permission naming (`resource.{table}.{action}`)
-
-Prefer a custom (hand‑written) controller when:
-- You need multi‑table joins, aggregations, or transactional workflows
-- Validation rules depend on context beyond simple field constraints
-- You must orchestrate side‑effects (emails, events, external APIs) tightly per action
-- Response payloads diverge significantly from base table rows (embedding, projections, domain DTOs)
-- You want to version or stage breaking changes without affecting other tables sharing the generic endpoint
-
-Hybrid strategy (common in larger apps):
-- Start with `ResourceController` for rapid iteration
-- Promote specific tables to dedicated controllers as complexity or specialization grows
-- Keep the generic route mounted for the rest
-
-To “promote” a table: add explicit routes (e.g. `/posts/...`) pointing to `PostController` and optionally restrict or deny that table inside `ResourceController::applyTableAccessControl` so the generic path no longer serves it.
-
-### Route Registration & Customization
-
-The generic CRUD routes are already declared in `framework/routes/resource.php` and include inline OpenAPI–style annotations plus middleware (`auth`, rate limits per verb). You normally do not need to re‑declare them.
-
-Customization approaches:
-1. Override behavior via subclass: Bind `ResourceController::class` to your subclass in the container (e.g. in a service provider) to change defaults globally.
-2. Per‑table hardening: Override `applyTableAccessControl` to whitelist tables or escalate permissions for sensitive ones.
-3. Disable generic for a specific table: Add logic in `applyTableAccessControl` to throw/require a special permission, then supply bespoke routes in your app’s `routes/` folder.
-4. Adjust limits: Wrap or subclass and change calls to `rateLimitResource` (or provide config consumed by your override methods).
-5. Bulk operations: Enable via config key `resource.security.bulk_operations` to expose the extra `/bulk` endpoints already conditionally registered.
-
-This keeps the default file as the canonical definition while allowing layered extensibility.
-
-## Request Handling
-
-### Getting Input
-
-```php
-public function store()
-{
-    // All input (JSON or form)
-    $all = $this->getRequestData();
-
-    // Specific field
-    $email = $all['email'] ?? null; // or: $this->request->request->get('email')
-
-    // With default (request bag)
-    $name = $this->request->request->get('name', 'Guest');
-
-    // Check if field exists
-    if ($this->request->request->has('email')) {
-        //...
-    }
-}
-```
-
-### Route Parameters
-
-```php
-// Route: /users/{uuid}/posts/{postUuid}
-public function show(string $uuid, string $postUuid)
-{
-    $user = $this->db->table('users')->where('uuid', $uuid)->first();
-    $post = $this->db->table('posts')->where('uuid', $postUuid)->first();
-
-    return Response::success(['user' => $user, 'post' => $post]);
-}
-```
-
-### Query Parameters
-
-```php
-public function index()
-{
-    $page = (int) $this->request->query->get('page', 1);
-    $limit = (int) $this->request->query->get('limit', 20);
-
-    $users = $this->db->table('users')
-        ->limit($limit)
-        ->offset(($page - 1) * $limit)
-        ->get();
-
-    return Response::success($users);
-}
-```
-
-## Validation
-
-Validate input before processing:
-
-```php
-public function store()
-{
-    $data = $this->getRequestData();
-    if ($error = $this->validateRequest($data, [
-        'email' => 'required|email',
-        'name' => 'required|max:100',
-    ])) {
-        return $error; // 422
-    }
-
-    $user = $this->db->table('users')->insert([
-        'uuid' => Utils::generateNanoID(),
-        'email' => $data['email'],
-        'name' => $data['name'],
-    ]);
-
-    return $this->created($user);
-}
-```
-
-Returns `422` response automatically if validation fails.
-
-## Common Patterns
-
-### RESTful CRUD
-
-```php
-class PostController extends BaseController
-{
-    public function index()
-    {
-        // GET /posts - List all
-    $posts = $this->db->table('posts')->get();
-    return $this->success($posts);
-    }
-
-    public function store()
-    {
-        // POST /posts - Create
-        $data = $this->getRequestData();
-        $post = $this->db->table('posts')->insert([
-            'uuid' => Utils::generateNanoID(),
-            'title' => $data['title'] ?? 'Untitled',
-            'body' => $data['body'] ?? null,
-        ]);
-        return $this->created($post);
-    }
-
-    public function show(string $uuid)
-    {
-        // GET /posts/{uuid} - Show one
-        $post = $this->db->table('posts')->where('uuid', $uuid)->first();
-        return $post ? $this->success($post) : $this->notFound('Post not found');
-    }
-
-    public function update(string $uuid)
-    {
-        // PUT /posts/{uuid} - Update
-        $data = $this->getRequestData();
-        $updated = $this->db->table('posts')->where('uuid', $uuid)->update($data);
-        return $updated ? $this->success(null, 'Updated') : $this->notFound('Post not found');
-    }
-
-    public function destroy(string $uuid)
-    {
-        // DELETE /posts/{uuid} - Delete
-        $deleted = $this->db->table('posts')->where('uuid', $uuid)->delete();
-        return $deleted ? Response::noContent() : $this->notFound('Post not found');
-    }
-}
-```
-
-### Error Handling
-
-```php
-public function show(string $id)
-{
-    $user = $this->db->table('users')
-        ->where('uuid', $id)
-        ->first();
-
-    if (!$user) {
-    return $this->notFound('User not found');
-    }
-
-    return $this->success($user);
-}
-```
-
-### Pagination
-
-```php
-public function index()
-{
-    $page = (int) $this->request->query->get('page', 1);
-    $perPage = (int) $this->request->query->get('per_page', 20);
-
-    $users = $this->db->table('users')
-        ->limit($perPage)
-        ->offset(($page - 1) * $perPage)
-        ->get();
-
-    $total = $this->db->table('users')->count();
-
-    return Response::paginated($users, $total, $page, $perPage);
-}
-```
-
-## Organization Tips
-
-### Keep Controllers Thin
-
-Extract business logic to services:
-
-```php
-// ❌ Fat controller
-class OrderController extends BaseController
-{
-    public function store()
-    {
-    $data = $this->getRequestData();
-
-        // Validate
-        // Calculate totals
-        // Check inventory
-        // Process payment
-        // Send emails
-        // Update stock
-        // Create order
-
-        return Response::created($order);
-    }
-}
-
-// ✅ Thin controller with service
-class OrderController extends BaseController
-{
-    public function __construct(
-        private OrderService $orders
-    ) {}
-
-    public function store()
-    {
-    $data = $this->getRequestData();
-        $order = $this->orders->create($data);
-        return Response::created($order);
-    }
-}
-```
-
-### Use Sub-Controllers
-
-Break large controllers into focused ones:
-
-```php
-// Instead of one massive UserController
-UserController
-UserProfileController
-UserSettingsController
-UserNotificationsController
-```
-
-## Next Steps
-
-- [Requests & Responses](requests-responses) - Work with HTTP data
-- [Validation](validation) - Validate input
-- [Database](database) - Query data
+For most new applications, start with explicit controllers in `app/Controllers` and move to generic resource wiring only when the tradeoff is clear.

--- a/content/2.essentials/6.validation.md
+++ b/content/2.essentials/6.validation.md
@@ -1,383 +1,128 @@
 ---
 title: Validation
-description: Validate user input using rule objects
+description: Validate request data with BaseController helpers or rule objects
 ---
 
-Validate request data before processing to ensure data integrity and security.
+Glueful currently has two practical validation styles you will encounter:
 
-Glueful uses an object-based validation API. You compose a Validator with Rule objects per field, validate input to produce an error map, and work with sanitized data via filtered().
+1. **`BaseController::validateRequest()`** for simple controller-level checks
+2. **Rule objects with `Glueful\Validation\Validator`** for more explicit validation flows
 
-## Basic Validation
+## Simple Validation In Controllers
 
-Use `Glueful\Validation\Support\Rules::of()` to build a `Validator` with Rule objects. Throw `Glueful\Validation\ValidationException` to trigger a 422 response via the ValidationMiddleware.
+If you are using `BaseController`, this is the shortest path:
 
 ```php
-use Glueful\Validation\Support\Rules as RuleFactory;
-use Glueful\Validation\ValidationException;
-use Glueful\Validation\Rules\{Sanitize, Required, Email as EmailRule, Length, Range, Type};
-
-public function store()
+public function store(\Symfony\Component\HttpFoundation\Request $request): \Glueful\Http\Response
 {
-    $input = $this->request->input();
+    $data = $this->getRequestData();
 
-    $v = RuleFactory::of([
-        'email' => [new Sanitize(['trim','strip_tags']), new Required(), new EmailRule()],
-        'name'  => [new Sanitize(['trim','strip_tags']), new Required(), new Length(2, 50)],
-        'age'   => [new Type('integer'), new Range(18, 120)], // null is allowed unless Required() is added
-    ]);
-
-    $errors = $v->validate($input);
-    if ($errors !== []) {
-        throw new ValidationException($errors); // Handled as 422 by middleware
+    if ($error = $this->validateRequest($data, [
+        'email' => 'required|email|max:255',
+        'name' => 'required|max:100',
+    ])) {
+        return $error;
     }
 
-    $data = $v->filtered(); // sanitized values
-
-    $user = $this->db->table('users')->insert([
+    return $this->created([
         'email' => $data['email'],
-        'name'  => $data['name'],
-        'age'   => $data['age'] ?? null,
+        'name' => $data['name'],
     ]);
-
-    return Response::created($user);
 }
 ```
 
-When `ValidationException` is thrown and the `ValidationMiddleware` is active, a `422` JSON is returned with a consistent shape:
+This helper is intentionally lightweight. It is good for straightforward endpoint validation.
 
-```json
-{
-  "status": 422,
-  "message": "Validation failed",
-  "errors": {
-    "email": ["This field is required."],
-    "name": ["Must be at least 2 characters."]
-  }
-}
-```
+## Rule Object Validation
 
-## Validation Rules
-
-Glueful provides a focused set of Rule classes. Rules return an error message string or null if the value passes. Most rules treat `null` as “skip” — add `Required()` to enforce presence.
-
-### Required
-
-```php
-use Glueful\Validation\Rules\Required;
-$rules = [ 'email' => [new Required()] ];
-```
-
-### Email
-
-```php
-use Glueful\Validation\Rules\Email as EmailRule;
-$rules = [ 'email' => [new EmailRule()] ];
-```
-
-### Length (strings)
-
-```php
-use Glueful\Validation\Rules\Length;
-$rules = [ 'name' => [new Length(2, 50)] ];
-```
-
-### Range (integers)
-
-```php
-use Glueful\Validation\Rules\Range;
-$rules = [ 'age' => [new Range(18, 120)] ];
-```
-
-### Type
-
-```php
-use Glueful\Validation\Rules\Type;
-$rules = [
-    'age' => [new Type('integer')],
-    'tags' => [new Type('array')],
-];
-```
-
-### InArray (enum-style)
-
-```php
-use Glueful\Validation\Rules\InArray;
-$rules = [ 'status' => [new InArray(['active','inactive','suspended'])] ];
-```
-
-### DbUnique
-
-```php
-use Glueful\Validation\Rules\DbUnique;
-
-// Using a PDO instance (inject or resolve from container)
-$pdo = container()->get(PDO::class);
-$rules = [ 'email' => [new Required(), new EmailRule(), new DbUnique($pdo, 'users', 'email')] ];
-```
-
-### Sanitize (mutating)
-
-```php
-use Glueful\Validation\Rules\Sanitize;
-$rules = [ 'name' => [new Sanitize(['trim','strip_tags','lower'])] ];
-```
-
-## Available Rules
-
-Supported out of the box:
-- Required — field must be present and not empty
-- Email — RFC-compliant email address
-- Type — enforce PHP type, e.g. 'string', 'integer', 'array'
-- Length — string length min/max
-- Range — integer min/max
-- InArray — value must be one of a given list (strict)
-- DbUnique — value must be unique in a database table/column (requires PDO)
-- Sanitize — mutate value (trim/strip_tags/upper/lower) before other rules
-
-Notes:
-- There is no string rule syntax (e.g., `"required|min:2"`). Use Rule objects.
-- Most rules skip `null`; add `Required()` to enforce presence.
-- For unsupported cases (URL, dates, regex, files), create custom Rule classes or use dedicated services.
-
-## Custom Rules
-
-To customize messages/logic, implement your own Rule:
-
-```php
-use Glueful\Validation\Contracts\Rule;
-
-final class RegexRule implements Rule
-{
-    public function __construct(private string $pattern, private string $message)
-    {
-    }
-
-    public function validate(mixed $value, array $context = []): ?string
-    {
-        if ($value === null) return null;
-        return is_string($value) && preg_match($this->pattern, $value) === 1
-            ? null
-            : $this->message;
-    }
-}
-```
-
-## Patterns
-
-### Nested/Array Data
-
-There is no wildcard syntax. Validate containers and then loop items yourself:
+For stricter or reusable validation, use `Validator` with rule objects:
 
 ```php
 use Glueful\Validation\Support\Rules as RuleFactory;
-use Glueful\Validation\Rules\{Required, Type, Range};
 use Glueful\Validation\ValidationException;
+use Glueful\Validation\Rules\{
+    Required,
+    Email as EmailRule,
+    Length,
+    Type,
+    Range
+};
 
-$v = RuleFactory::of([
-    'items' => [new Required(), new Type('array')],
-]);
-
-$errors = $v->validate($input);
-if ($errors) throw new ValidationException($errors);
-
-$data = $v->filtered();
-$itemErrors = [];
-foreach (($data['items'] ?? []) as $i => $item) {
-    $iv = RuleFactory::of([
-        'quantity' => [new Required(), new Type('integer'), new Range(1, 1000)],
-    ]);
-    $errs = $iv->validate($item);
-    if ($errs) $itemErrors["items.$i"] = $errs;
-}
-if ($itemErrors) throw new ValidationException($itemErrors);
-```
-
-### Conditional Rules
-
-Compose additional validators depending on input state:
-
-```php
-$base = RuleFactory::of([
-    'payment_method' => [new Required(), new InArray(['credit_card','paypal','bank_transfer'])],
-]);
-if ($errs = $base->validate($input)) throw new ValidationException($errs);
-
-if (($input['payment_method'] ?? null) === 'credit_card') {
-    $cc = RuleFactory::of([
-        // provide your own RegexRule or specialized Rule implementation
-        // 'card_number' => [new RegexRule('/^\d{16}$/', 'Card must be 16 digits')],
-    ]);
-    if ($errs = $cc->validate($input)) throw new ValidationException($errs);
-}
-```
-
-## Manual Validation
-
-Use `Validator` directly when needed:
-
-```php
-use Glueful\Validation\Validator;
-use Glueful\Validation\Rules\{Required, Email as EmailRule};
-
-$validator = new Validator([
+$validator = RuleFactory::of([
     'email' => [new Required(), new EmailRule()],
+    'name' => [new Required(), new Length(2, 100)],
+    'age' => [new Type('integer'), new Range(18, 120)],
 ]);
 
 $errors = $validator->validate($input);
-if ($errors) throw new \Glueful\Validation\ValidationException($errors);
+
+if ($errors !== []) {
+    throw new ValidationException($errors);
+}
 
 $data = $validator->filtered();
-// Continue processing with $data
 ```
 
-## Common Patterns
+`Type('integer')` is strict. It works well for JSON payloads where numeric values are decoded as integers. For form-encoded input, values usually arrive as strings, so use it only when that strictness is what you want.
 
-### User Registration
+## Useful Built-In Rules
+
+- `Required`
+- `Email`
+- `Length`
+- `Range`
+- `Type`
+- `InArray`
+- `Sanitize`
+- `DbUnique`
+
+### Example: `DbUnique`
 
 ```php
-use Glueful\Validation\Support\Rules as RuleFactory;
-use Glueful\Validation\ValidationException;
-use Glueful\Validation\Rules\{Sanitize, Required, Email as EmailRule, Length};
+use PDO;
+use Glueful\Validation\Rules\DbUnique;
 
-public function register()
-{
-    $input = $this->request->input();
+$pdo = new PDO($dsn, $user, $password);
 
-    $v = RuleFactory::of([
-        'name' => [new Sanitize(['trim','strip_tags']), new Required(), new Length(2, 100)],
-        'email' => [new Sanitize(['trim']), new Required(), new EmailRule()],
-        'password' => [new Required(), new Length(8, 255)],
-    ]);
-
-    if ($errors = $v->validate($input)) {
-        throw new ValidationException($errors);
-    }
-
-    $data = $v->filtered();
-
-    $user = $this->db->table('users')->insert([
-        'name' => $data['name'],
-        'email' => $data['email'],
-        'password' => password_hash($data['password'], PASSWORD_DEFAULT),
-    ]);
-
-    return Response::created($user);
-}
+$rules = [
+    'email' => [
+        new Required(),
+        new EmailRule(),
+        new DbUnique($pdo, 'users', 'email'),
+    ],
+];
 ```
 
-### Profile Update
+For direct `Validator` usage, pass a PDO instance explicitly. Do not assume the validator will inject one automatically.
+
+## When To Use Which Style
+
+- Use `validateRequest()` for simple app controllers in `api-skeleton`
+- Use rule objects when you need sanitization, custom rules, or more explicit composition
+
+## ValidationException Shape
+
+When you throw `ValidationException`, it carries field errors and is designed to produce a `422` response:
 
 ```php
-use Glueful\Validation\Support\Rules as RuleFactory;
-use Glueful\Validation\ValidationException;
-use Glueful\Validation\Rules\{Sanitize, Email as EmailRule, Length, InArray, DbUnique};
-
-public function update(string $userId)
-{
-    $input = $this->request->input();
-    $pdo = container()->get(PDO::class);
-
-    $v = RuleFactory::of([
-        'name' => [new Sanitize(['trim','strip_tags']), new Length(2, 100)],
-        'email' => [new Sanitize(['trim']), new EmailRule(), new DbUnique($pdo, 'users', 'email')],
-        'status' => [new InArray(['active','inactive','suspended'])],
-        'bio' => [new Length(0, 500)],
-    ]);
-
-    if ($errors = $v->validate($input)) {
-        throw new ValidationException($errors);
-    }
-
-    $data = $v->filtered();
-
-    $this->db->table('users')
-        ->where('uuid', $userId)
-        ->update($data);
-
-    return Response::success(null, 'Profile updated');
-}
-```
-
-### File Upload
-
-File validation (type/MIME/size) is handled by dedicated uploader and image services. Use those rather than validation rules:
-
-```php
-use Glueful\Uploader\FileUploader;
-
-public function uploadAvatar()
-{
-    $fileUploader = container()->get(FileUploader::class);
-    $result = $fileUploader->upload($this->request->files()['avatar']);
-    // $result contains normalized file data and storage path per your uploader config
-    return Response::success($result);
-}
-```
-
-## Best Practices
-
-### Validate Early
-
-```php
-// ✅ Validate before any processing
-public function store()
-{
-    $validated = $this->validate($this->request->input(), [...]);
-    // Now safe to use $validated
-}
-
-// ❌ Don't use unvalidated input
-public function store()
-{
-    $email = $this->request->input('email'); // Not validated!
-    // ...
-}
-```
-
-### Optional Fields
-
-```php
-// Optional unless Required() is added
-$v = RuleFactory::of([
-    'name' => [new Required()],
-    'bio' => [new Length(0, 500)], // if present, must be <= 500 chars
+throw new ValidationException([
+    'email' => ['The email field is required.'],
+    'name' => ['The name must be at least 2 characters.'],
 ]);
 ```
 
-### Validate Arrays Properly
+## Recommended Starting Pattern
+
+For most first-party app endpoints, start simple:
 
 ```php
-// ✅ Validate container and then each tag manually
-$v = RuleFactory::of([
-    'tags' => [new Type('array')],
-]);
-$errors = $v->validate($input);
-if (!$errors) {
-    foreach (($v->filtered()['tags'] ?? []) as $i => $tag) {
-        $tv = RuleFactory::of(['tag' => [new Length(1, 20)]]);
-        $te = $tv->validate(['tag' => $tag]);
-        if ($te) $errors["tags.$i"] = $te;
-    }
+$data = $this->getRequestData();
+
+if ($error = $this->validateRequest($data, [
+    'title' => 'required|max:255',
+])) {
+    return $error;
 }
-if ($errors) throw new ValidationException($errors);
 ```
 
-## Troubleshooting
-
-**Validation always fails?**
-- Check field names match exactly
-- Ensure you’re using Rule objects (not string rules)
-- Ensure data is being sent in request
-
-**Custom messages not showing?**
-- Messages are defined by each Rule. For custom text, write a custom Rule.
-
-**Unique rule not working?**
-- Verify table and column names are correct
-- Ensure your PDO connection is valid
-
-## Next Steps
-
-- [Controllers](controllers) - Organize validation logic
-- [Database](database) - Store validated data
-- [Requests & Responses](requests-responses) - Handle validated input
+Move to rule objects once the endpoint needs more than basic checks.

--- a/content/3.features/cors-csrf.md
+++ b/content/3.features/cors-csrf.md
@@ -117,7 +117,7 @@ Access-Control-Max-Age: 86400
 
 Glueful’s router centralizes CORS handling:
 
-- Reads settings from `config/cors.php` via `config('cors')`.
+- Reads settings from `config/cors.php` via `config($context, 'cors')`.
 - For `OPTIONS` preflight, returns `204 No Content` with CORS headers and an `Allow` header listing permitted methods.
 - For normal requests, sets:
   - `Access-Control-Allow-Origin` to the request Origin if allowed (or `*` if `allow_all_origins` is true)

--- a/content/3.features/distributed-locks.md
+++ b/content/3.features/distributed-locks.md
@@ -12,7 +12,7 @@ Prevent duplicate or overlapping execution of critical sections across workers o
 ```php
 use Glueful\Lock\LockManagerInterface;
 
-$lockManager = app(LockManagerInterface::class);
+$lockManager = app($context, LockManagerInterface::class);
 
 // Execute once, safely across processes
 $result = $lockManager->executeWithLock('import:daily-customers', function () {
@@ -29,7 +29,7 @@ try {
     }, maxWait: 30.0, ttl: 600);
 } catch (\Symfony\Component\Lock\Exception\LockConflictedException $e) {
     // Timed out waiting
-    logger()->warning('Warehouse sync busy, skipped');
+    app($context, \Psr\Log\LoggerInterface::class)->warning('Warehouse sync busy, skipped');
 }
 ```
 
@@ -45,7 +45,7 @@ if ($lock->acquire()) {
         $lock->release();
     }
 } else {
-    logger()->info('Index rebuild already in progress');
+    app($context, \Psr\Log\LoggerInterface::class)->info('Index rebuild already in progress');
 }
 ```
 
@@ -93,7 +93,7 @@ foreach (array_chunk($userIds, 500) as $chunk) {
 
 ```php
 if ($lockManager->isLocked('cache:warm')) {
-    logger()->info('Cache warming already in progress');
+    app($context, \Psr\Log\LoggerInterface::class)->info('Cache warming already in progress');
     return;
 }
 
@@ -273,13 +273,13 @@ try {
     }, 300);
 } catch (LockConflictedException $e) {
     // Lock already held
-    logger()->info('Inventory sync skipped: already running');
+    app($context, \Psr\Log\LoggerInterface::class)->info('Inventory sync skipped: already running');
 
     // Optionally queue for retry
-    $queue = app(\Glueful\Queue\QueueManager::class);
+    $queue = app($context, \Glueful\Queue\QueueManager::class);
     $queue->push(RetryInventorySyncJob::class, [], queue: null, connection: null);
 } catch (\Throwable $e) {
-    logger()->error('Inventory sync failed', ['error' => $e->getMessage()]);
+    app($context, \Psr\Log\LoggerInterface::class)->error('Inventory sync failed', ['error' => $e->getMessage()]);
     throw $e;
 }
 ```
@@ -322,12 +322,12 @@ Track lock performance:
 $start = microtime(true);
 
 $lockManager->executeWithLock('feed:refresh', function () {
-    logger()->info('Refreshing feed with exclusive lock');
+    app($context, \Psr\Log\LoggerInterface::class)->info('Refreshing feed with exclusive lock');
     refreshFeed();
 });
 
 $duration = microtime(true) - $start;
-logger()->info('Lock held for ' . $duration . 's');
+app($context, \Psr\Log\LoggerInterface::class)->info('Lock held for ' . $duration . 's');
 ```
 
 ### Key Metrics

--- a/content/3.features/events.md
+++ b/content/3.features/events.md
@@ -34,11 +34,11 @@ use App\Events\UserRegisteredEvent;
 
 Event::listen(UserRegisteredEvent::class, function($event) {
     // Send welcome email (queue async)
-    $queue = app(\Glueful\Queue\QueueManager::class);
+    $queue = app($context, \Glueful\Queue\QueueManager::class);
     $queue->push(SendWelcomeEmailJob::class, ['user_id' => $event->userId]);
 
     // Track in analytics (pseudo)
-    app('analytics')->track('user.registered', [
+    app($context, 'analytics')->track('user.registered', [
         'user_id' => $event->userId
     ]);
 });
@@ -83,7 +83,7 @@ Event::dispatch(new OrderPlacedEvent($orderId, $total));
 ```php
 // Closure listener
 Event::listen(OrderPlacedEvent::class, function($event) {
-    logger()->info('Order placed', ['id' => $event->orderId]);
+    app($context, \Psr\Log\LoggerInterface::class)->info('Order placed', ['id' => $event->orderId]);
 });
 
 // Class listener (optionally via service container reference)
@@ -135,12 +135,12 @@ Queue expensive listeners:
 ```php
 Event::listen(UserRegisteredEvent::class, function($event) {
     // This listener runs synchronously
-    logger()->info('User registered');
+    app($context, \Psr\Log\LoggerInterface::class)->info('User registered');
 });
 
 Event::listen(UserRegisteredEvent::class, function($event) {
     // Queue this expensive work
-    $queue = app(\Glueful\Queue\QueueManager::class);
+    $queue = app($context, \Glueful\Queue\QueueManager::class);
     $queue->push(ProcessNewUserJob::class, ['user_id' => $event->userId]);
 });
 ```
@@ -165,7 +165,7 @@ class UserRegisteredEvent extends BaseEvent
 // Listeners
 Event::listen(UserRegisteredEvent::class, function($event) {
     // Send welcome email
-    $queue = app(\Glueful\Queue\QueueManager::class);
+    $queue = app($context, \Glueful\Queue\QueueManager::class);
     $queue->push(SendWelcomeEmailJob::class, ['user_id' => $event->userId]);
 });
 
@@ -178,7 +178,7 @@ Event::listen(UserRegisteredEvent::class, function($event) {
 
 Event::listen(UserRegisteredEvent::class, function($event) {
     // Create default preferences
-    db()->table('user_preferences')->insert([
+    db($context)->table('user_preferences')->insert([
         'user_id' => $event->userId,
         'notifications' => true
     ]);
@@ -208,19 +208,19 @@ class OrderPlacedEvent extends BaseEvent
 
 // Process payment
 Event::listen(OrderPlacedEvent::class, function($event) {
-    app(\Glueful\Queue\QueueManager::class)
+    app($context, \Glueful\Queue\QueueManager::class)
         ->push(ProcessPaymentJob::class, ['order_id' => $event->orderId]);
 });
 
 // Send confirmation
 Event::listen(OrderPlacedEvent::class, function($event) {
-    app(\Glueful\Queue\QueueManager::class)
+    app($context, \Glueful\Queue\QueueManager::class)
         ->push(SendOrderConfirmationJob::class, ['order_id' => $event->orderId]);
 });
 
 // Update inventory
 Event::listen(OrderPlacedEvent::class, function($event) {
-    app(\Glueful\Queue\QueueManager::class)
+    app($context, \Glueful\Queue\QueueManager::class)
         ->push(UpdateInventoryJob::class, ['order_id' => $event->orderId]);
 });
 ```
@@ -258,7 +258,7 @@ Glueful emits these events automatically:
 use Glueful\Events\Http\RequestEvent;
 
 Event::listen(RequestEvent::class, function($event) {
-    logger()->info('Request', [
+    app($context, \Psr\Log\LoggerInterface::class)->info('Request', [
         'method' => $event->request->getMethod(),
         'path' => $event->request->getPathInfo()
     ]);
@@ -268,7 +268,7 @@ Event::listen(RequestEvent::class, function($event) {
 use Glueful\Events\Http\ResponseEvent;
 
 Event::listen(ResponseEvent::class, function($event) {
-    logger()->info('Response', [
+    app($context, \Psr\Log\LoggerInterface::class)->info('Response', [
         'status' => $event->response->getStatusCode()
     ]);
 });
@@ -281,14 +281,14 @@ Event::listen(ResponseEvent::class, function($event) {
 use Glueful\Events\Auth\SessionCreatedEvent;
 
 Event::listen(SessionCreatedEvent::class, function($event) {
-    logger()->info('User logged in', ['user_id' => $event->userId]);
+    app($context, \Psr\Log\LoggerInterface::class)->info('User logged in', ['user_id' => $event->userId]);
 });
 
 // Login failure
 use Glueful\Events\Auth\AuthenticationFailedEvent;
 
 Event::listen(AuthenticationFailedEvent::class, function($event) {
-    logger()->warning('Login failed', ['email' => $event->email]);
+    app($context, \Psr\Log\LoggerInterface::class)->warning('Login failed', ['email' => $event->email]);
 });
 ```
 
@@ -318,7 +318,7 @@ use Glueful\Events\Database\QueryExecutedEvent;
 
 Event::listen(QueryExecutedEvent::class, function($event) {
     if ($event->time > 100) { // 100ms
-        logger()->warning('Slow query', [
+        app($context, \Psr\Log\LoggerInterface::class)->warning('Slow query', [
             'sql' => $event->sql,
             'time' => $event->time
         ]);
@@ -356,7 +356,7 @@ return [
 ```php
 // ✅ Good - quick logging
 Event::listen(OrderPlacedEvent::class, function($event) {
-    logger()->info('Order placed', ['id' => $event->orderId]);
+    app($context, \Psr\Log\LoggerInterface::class)->info('Order placed', ['id' => $event->orderId]);
 });
 
 // ❌ Bad - slow API call
@@ -458,7 +458,7 @@ Event::listen(PostCreatedEvent::class, function($event) {
 });
 
 Event::listen(PostCreatedEvent::class, function($event) {
-    app(\Glueful\Queue\QueueManager::class)
+    app($context, \Glueful\Queue\QueueManager::class)
         ->push(NotifySubscribersJob::class, ['post_uuid' => $event->postUuid]);
 });
 ```

--- a/content/3.features/field-selection.md
+++ b/content/3.features/field-selection.md
@@ -133,7 +133,7 @@ The projector records N+1 risk detections and projection metrics via `FieldSelec
 Middleware defaults (overridable per route via metadata/attributes):
 
 ```php
-// config('api.field_selection') if using the config helper
+// config($context, 'api.field_selection') if using the config helper
 [
   'strict'     => false,
   'maxDepth'   => 6,

--- a/content/3.features/file-uploads.md
+++ b/content/3.features/file-uploads.md
@@ -9,17 +9,20 @@ Securely accept and store file uploads with automatic validation, storage, and U
 
 ```php
 use Glueful\Uploader\FileUploader;
-use Glueful\Storage\Support\UrlGenerator;
+use Glueful\Http\Response;
 
 public function upload()
 {
-    $uploader = app(FileUploader::class);
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
+
+    $uploader = app($this->getContext(), FileUploader::class);
 
     $result = $uploader->handleUpload(
-        token: $this->request->input('token'),
-        // Include user_id as required by uploader validation
+        token: $this->currentUser->uuid,
         getParams: array_merge($this->request->query->all(), [
-            'user_id' => (string) ($this->auth?->user()->uuid ?? '')
+            'user_id' => $this->currentUser->uuid
         ]),
         fileParams: $this->request->files->all()
     );
@@ -46,10 +49,10 @@ return [
     'disks' => [
         'uploads' => [
             'driver' => 'local',
-            'root' => config('app.paths.uploads'),
+            'root' => env('UPLOADS_ROOT', dirname(__DIR__) . '/storage/uploads'),
             'visibility' => 'private',
             // Used by UrlGenerator for public URLs
-            'base_url' => config('app.urls.cdn'),
+            'base_url' => env('UPLOADS_BASE_URL', 'http://localhost:8080/uploads'),
         ],
 
         's3' => [
@@ -84,13 +87,17 @@ return [
 ```php
 public function uploadAvatar()
 {
-    $uploader = app(FileUploader::class);
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
+
+    $uploader = app($this->getContext(), FileUploader::class);
 
     $result = $uploader->handleUpload(
-        token: $this->auth->user()->uuid,
+        token: $this->currentUser->uuid,
         getParams: [
             'type' => 'avatar',
-            'user_id' => (string) $this->auth->user()->uuid
+            'user_id' => $this->currentUser->uuid
         ],
         fileParams: $this->request->files->all()
     );
@@ -101,7 +108,7 @@ public function uploadAvatar()
 
     // Update user avatar
     $this->getConnection()->table('users')
-        ->where(['uuid' => $this->auth->user()->uuid])
+        ->where(['uuid' => $this->currentUser->uuid])
         ->update(['avatar' => $result['url']]);
 
     return Response::success(['url' => $result['url']]);
@@ -113,14 +120,18 @@ public function uploadAvatar()
 ```php
 public function uploadGallery()
 {
-    $uploader = app(FileUploader::class);
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
+
+    $uploader = app($this->getContext(), FileUploader::class);
     $files = $this->request->files->all();
     $uploaded = [];
 
     foreach ($files as $file) {
         $result = $uploader->handleUpload(
-            token: $this->auth->user()->uuid,
-            getParams: ['user_id' => (string) $this->auth->user()->uuid],
+            token: $this->currentUser->uuid,
+            getParams: ['user_id' => $this->currentUser->uuid],
             fileParams: ['file' => $file]
         );
 
@@ -142,7 +153,7 @@ For images, videos, and audio files, use `uploadMedia()` to get automatic thumbn
 ```php
 public function uploadMedia()
 {
-    $uploader = app(FileUploader::class);
+    $uploader = app($this->getContext(), FileUploader::class);
     $file = $this->request->files->get('file');
 
     $result = $uploader->uploadMedia($file, 'posts/' . $postUuid);
@@ -277,7 +288,7 @@ return [
 ```php
 public function upload()
 {
-    $file = $this->request->file('file');
+    $file = $this->request->files->get('file');
 
     // Validate size
     if ($file->getSize() > 5242880) { // 5MB
@@ -332,7 +343,7 @@ composer require league/flysystem-ftp
 ```php
 'uploads' => [
     'driver' => 'local',
-    'root' => storage_path('uploads'),
+    'root' => storage_path($context, 'uploads'),
     'visibility' => 'private',
 ],
 ```
@@ -377,13 +388,14 @@ composer require league/flysystem-ftp
 ```php
 use Glueful\Storage\StorageManager;
 
-$storage = app(StorageManager::class);
+$storage = app($this->getContext(), StorageManager::class);
 
 // Store file content
 $storage->disk()->put('avatars/user123.jpg', $fileContent);
 
-// Store uploaded file
-$path = $this->request->file('avatar')->store('avatars');
+// Work with the uploaded file from Symfony's request object
+$uploadedFile = $this->request->files->get('avatar');
+$path = 'avatars/' . $uploadedFile->getClientOriginalName();
 ```
 
 ### Retrieve File
@@ -422,7 +434,7 @@ foreach ($files as $attr) {
 ```php
 use Glueful\Storage\Support\UrlGenerator;
 
-$urls = app(UrlGenerator::class);
+$urls = app($this->getContext(), UrlGenerator::class);
 
 $publicUrl = $urls->url('avatars/user123.jpg', 'uploads');
 // https://cdn.example.com/avatars/user123.jpg
@@ -436,7 +448,7 @@ For private files, generate temporary signed URLs:
 use Glueful\Uploader\Storage\FlysystemStorage;
 use Glueful\Storage\StorageManager;
 
-$storage = app(StorageManager::class);
+$storage = app($this->getContext(), StorageManager::class);
 $disk = new FlysystemStorage($storage, $urls, 's3');
 
 $signedUrl = $disk->getSignedUrl('documents/invoice.pdf', 3600);
@@ -450,10 +462,14 @@ $signedUrl = $disk->getSignedUrl('documents/invoice.pdf', 3600);
 ```php
 public function updateAvatar()
 {
-    $uploader = app(FileUploader::class);
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
+
+    $uploader = app($this->getContext(), FileUploader::class);
 
     $result = $uploader->handleUpload(
-        token: $this->auth->user()->uuid,
+        token: $this->currentUser->uuid,
         getParams: [],
         fileParams: $this->request->files->all()
     );
@@ -463,15 +479,18 @@ public function updateAvatar()
     }
 
     // Delete old avatar
-    $storage = app(\Glueful\Storage\StorageManager::class);
-    $user = $this->auth->user();
-    if ($user->avatar) {
-        $storage->disk()->delete($user->avatar);
+    $storage = app($this->getContext(), \Glueful\Storage\StorageManager::class);
+    $user = $this->getConnection()->table('users')
+        ->where(['uuid' => $this->currentUser->uuid])
+        ->first();
+
+    if (($user['avatar'] ?? null) !== null) {
+        $storage->disk()->delete($user['avatar']);
     }
 
     // Update user
     $this->getConnection()->table('users')
-        ->where(['uuid' => $user->uuid])
+        ->where(['uuid' => $this->currentUser->uuid])
         ->update(['avatar' => $result['path']]);
 
     return Response::success(['url' => $result['url']]);
@@ -483,8 +502,12 @@ public function updateAvatar()
 ```php
 public function uploadDocument()
 {
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
+
     // Validate file type
-    $file = $this->request->file('document');
+    $file = $this->request->files->get('document');
     $allowedTypes = ['application/pdf', 'application/msword'];
 
     if (!in_array($file->getMimeType(), $allowedTypes)) {
@@ -492,10 +515,10 @@ public function uploadDocument()
     }
 
     $result = $uploader->handleUpload(
-        token: $this->auth->user()->uuid,
+        token: $this->currentUser->uuid,
         getParams: [
             'type' => 'document',
-            'user_id' => (string) $this->auth->user()->uuid
+            'user_id' => $this->currentUser->uuid
         ],
         fileParams: $this->request->files->all()
     );
@@ -503,7 +526,7 @@ public function uploadDocument()
     // Store metadata
     $this->getConnection()->table('documents')->insert([
         'uuid' => $result['uuid'],
-        'user_uuid' => $this->auth->user()->uuid,
+        'user_uuid' => $this->currentUser->uuid,
         'filename' => $file->getClientOriginalName(),
         'path' => $result['path'],
         'size' => $file->getSize(),
@@ -519,8 +542,12 @@ public function uploadDocument()
 ```php
 public function uploadGalleryImage()
 {
-    $file = $this->request->file('image');
-    $uploader = app(FileUploader::class);
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
+
+    $file = $this->request->files->get('image');
+    $uploader = app($this->getContext(), FileUploader::class);
 
     // Validate image
     if (!str_starts_with($file->getMimeType(), 'image/')) {
@@ -528,7 +555,7 @@ public function uploadGalleryImage()
     }
 
     // Upload with automatic thumbnail generation
-    $result = $uploader->uploadMedia($file, 'gallery/' . $this->auth->user()->uuid, [
+    $result = $uploader->uploadMedia($file, 'gallery/' . $this->currentUser->uuid, [
         'thumbnail_width' => 300,
         'thumbnail_height' => 300,
     ]);
@@ -536,7 +563,7 @@ public function uploadGalleryImage()
     // Save to gallery table
     $this->getConnection()->table('gallery_images')->insert([
         'uuid' => $result['blob_uuid'],
-        'user_uuid' => $this->auth->user()->uuid,
+        'user_uuid' => $this->currentUser->uuid,
         'url' => $result['url'],
         'thumb_url' => $result['thumb_url'],
         'width' => $result['width'],
@@ -553,12 +580,16 @@ For API clients sending base64-encoded files, convert to a temp file and pass th
 
 ```php
 use Glueful\Uploader\FileUploader;
-use Glueful\Storage\StorageManager;
 
 public function uploadBase64()
 {
-    $base64 = (string) $this->request->input('file');
-    $uploader = app(FileUploader::class);
+    if ($this->currentUser === null) {
+        return $this->unauthorized();
+    }
+
+    $data = $this->getRequestData();
+    $base64 = (string) ($data['file'] ?? '');
+    $uploader = app($this->getContext(), FileUploader::class);
 
     try {
         // 1) Convert base64 to a temporary file path
@@ -582,8 +613,8 @@ public function uploadBase64()
 
     // 3) Reuse the same handleUpload() path with required getParams
     $result = $uploader->handleUpload(
-        token: (string) $this->auth->user()->uuid,
-        getParams: ['user_id' => (string) $this->auth->user()->uuid],
+        token: $this->currentUser->uuid,
+        getParams: ['user_id' => $this->currentUser->uuid],
         fileParams: $synthetic
     );
 
@@ -645,12 +676,12 @@ Generated filenames prevent guessing:
 ```php
 use Glueful\Uploader\FileUploader;
 
-$uploader = app(FileUploader::class);
+$uploader = app($this->getContext(), FileUploader::class);
 
 // Delete files older than 30 days
-$freed = $uploader->cleanupOldFiles('temp/', 2592000);
+$cleanup = $uploader->cleanupOldFiles('temp/', 2592000);
 
-logger()->info('Freed ' . $freed . ' bytes');
+logger()->info('Deleted ' . $cleanup['deleted_files'] . ' files');
 ```
 
 ### Directory Stats
@@ -699,7 +730,8 @@ $url = $urls->url($path);
 ```php
 // ✅ Good - async processing
 $result = $uploader->handleUpload(...);
-Queue::push(new ProcessImageJob($result['path']));
+app($this->getContext(), \Glueful\Queue\QueueManager::class)
+    ->push(ProcessImageJob::class, ['path' => $result['path']]);
 
 // ❌ Bad - blocks response
 $result = $uploader->handleUpload(...);

--- a/content/3.features/index.md
+++ b/content/3.features/index.md
@@ -34,7 +34,7 @@ $users = CacheHelper::remember($cache, 'users:active', function() {
 }, 3600);
 
 // Queue background jobs
-$queue = app(QueueManager::class);
+$queue = app($context, QueueManager::class);
 $queue->push(SendWelcomeEmail::class, [
     'user_uuid' => $user->uuid,
 ]);

--- a/content/3.features/notifications.md
+++ b/content/3.features/notifications.md
@@ -24,15 +24,16 @@ Register in `config/extensions.php`:
 ```php
 use Glueful\Notifications\Services\NotificationService;
 
-$notifications = app(NotificationService::class);
+$notifiable = new UserNotifiable('user-uuid', 'user@example.com');
+$notifications = app($this->getContext(), NotificationService::class);
 
 $notifications->send(
     type: 'user.welcome',
-    notifiable: $user,
+    notifiable: $notifiable,
     subject: 'Welcome to Glueful!',
     data: [
         'template' => 'welcome',
-        'name' => $user->name,
+        'name' => 'Jane Doe',
         'cta_url' => 'https://app.example.com/get-started'
     ]
 );
@@ -75,7 +76,7 @@ class UserNotifiable implements Notifiable
 use Glueful\Notifications\Services\NotificationService;
 
 $notifiable = new \App\Notifications\UserNotifiable($user['uuid'], $user['email']);
-app(NotificationService::class)->send(
+app($this->getContext(), NotificationService::class)->send(
     type: 'user.welcome',
     notifiable: $notifiable,
     subject: 'Welcome!',
@@ -90,18 +91,21 @@ app(NotificationService::class)->send(
 ```php
 public function register()
 {
-    // Create user
-    $user = $this->getConnection()->table('users')->insert($data);
+    $user = [
+        'uuid' => 'user-uuid',
+        'email' => 'user@example.com',
+        'name' => 'Jane Doe',
+    ];
+    $notifiable = new UserNotifiable($user['uuid'], $user['email']);
 
-    // Send welcome email
-    $notifications = app(\Glueful\Notifications\Services\NotificationService::class);
+    $notifications = app($this->getContext(), \Glueful\Notifications\Services\NotificationService::class);
     $notifications->send(
         type: 'user.welcome',
-        notifiable: $user,
+        notifiable: $notifiable,
         subject: 'Welcome!',
         data: [
             'template' => 'welcome',
-            'name' => $user->name
+            'name' => $user['name']
         ]
     );
 
@@ -114,7 +118,7 @@ public function register()
 ```php
 $notifications->send(
     type: 'order.confirmation',
-    notifiable: $user,
+    notifiable: $notifiable,
     subject: 'Order #' . $orderId,
     data: [
         'template' => 'order-confirmation',
@@ -154,11 +158,11 @@ $notifications->send(
 ```php
 $notifications->send(
     type: 'user.welcome',
-    notifiable: $user,
+    notifiable: $notifiable,
     subject: 'Welcome!',
     data: [
         'template' => 'welcome',  // Matches welcome.html
-        'name' => $user->name,
+        'name' => $user['name'],
         'cta_url' => 'https://app.example.com'
     ]
 );
@@ -181,7 +185,7 @@ Send notifications later:
 ```php
 $notifications->send(
     type: 'reminder',
-    notifiable: $user,
+    notifiable: $notifiable,
     subject: 'Don't forget!',
     data: ['template' => 'reminder'],
     options: [
@@ -197,7 +201,7 @@ Set notification priority:
 ```php
 $notifications->send(
     type: 'urgent.alert',
-    notifiable: $user,
+    notifiable: $notifiable,
     subject: 'Action Required',
     data: ['template' => 'alert'],
     options: [
@@ -232,20 +236,23 @@ Backoff strategies:
 ```php
 public function register()
 {
-    $user = $this->db->table('users')->insert([
-        'name' => $data['name'],
-        'email' => $data['email'],
-        'password' => password_hash($data['password'], PASSWORD_DEFAULT)
-    ]);
+    $data = $this->getRequestData();
+    $user = [
+        'uuid' => 'user-uuid',
+        'name' => $data['name'] ?? 'Jane Doe',
+        'email' => $data['email'] ?? 'user@example.com',
+    ];
+    $notifiable = new UserNotifiable($user['uuid'], $user['email']);
+    $notifications = app($this->getContext(), \Glueful\Notifications\Services\NotificationService::class);
 
     $notifications->send(
         type: 'user.registered',
-        notifiable: $user,
-        subject: 'Welcome to ' . config('app.name'),
+        notifiable: $notifiable,
+        subject: 'Welcome to Glueful',
         data: [
             'template' => 'welcome',
-            'name' => $user->name,
-            'verify_url' => url('/verify/' . $user->verification_token)
+            'name' => $user['name'],
+            'verify_url' => 'https://app.example.com/verify/' . $user['uuid']
         ]
     );
 
@@ -258,7 +265,8 @@ public function register()
 ```php
 public function forgotPassword()
 {
-    $email = $this->request->input('email');
+    $data = $this->getRequestData();
+    $email = $data['email'] ?? null;
     $user = $this->getConnection()->table('users')->where(['email' => $email])->first();
 
     if (!$user) {
@@ -273,15 +281,16 @@ public function forgotPassword()
         'created_at' => date('Y-m-d H:i:s')
     ]);
 
-    $notifications = app(\Glueful\Notifications\Services\NotificationService::class);
+    $notifications = app($this->getContext(), \Glueful\Notifications\Services\NotificationService::class);
+    $notifiable = new UserNotifiable($user['uuid'], $user['email']);
     $notifications->send(
         type: 'password.reset',
-        notifiable: $user,
+        notifiable: $notifiable,
         subject: 'Reset Your Password',
         data: [
             'template' => 'password-reset',
-            'name' => $user->name,
-            'reset_url' => url('/reset-password/' . $token)
+            'name' => $user['name'] ?? $user['email'],
+            'reset_url' => 'https://app.example.com/reset-password/' . $token
         ]
     );
 
@@ -294,21 +303,28 @@ public function forgotPassword()
 ```php
 public function placeOrder()
 {
-    $order = $this->getConnection()->table('orders')->insert($orderData);
-
-    $user = $this->getConnection()->table('users')->find($order->user_id);
-
-    $notifications = app(\Glueful\Notifications\Services\NotificationService::class);
+    $order = [
+        'id' => 1234,
+        'uuid' => 'order-uuid',
+        'total' => 149.99,
+        'user_uuid' => 'user-uuid',
+    ];
+    $user = [
+        'uuid' => 'user-uuid',
+        'email' => 'user@example.com',
+    ];
+    $notifiable = new UserNotifiable($user['uuid'], $user['email']);
+    $notifications = app($this->getContext(), \Glueful\Notifications\Services\NotificationService::class);
     $notifications->send(
         type: 'order.placed',
-        notifiable: $user,
-        subject: 'Order Confirmation #' . $order->id,
+        notifiable: $notifiable,
+        subject: 'Order Confirmation #' . $order['id'],
         data: [
             'template' => 'order-confirmation',
-            'order_id' => $order->id,
-            'total' => $order->total,
-            'items' => $this->getOrderItems($order->id),
-            'tracking_url' => url('/orders/' . $order->uuid)
+            'order_id' => $order['id'],
+            'total' => $order['total'],
+            'items' => $this->getOrderItems($order['id']),
+            'tracking_url' => 'https://app.example.com/orders/' . $order['uuid']
         ]
     );
 
@@ -325,19 +341,20 @@ public function sendWeeklyDigest()
         ->where(['digest_enabled' => true])
         ->get();
 
-    $notifications = app(\Glueful\Notifications\Services\NotificationService::class);
+    $notifications = app($this->getContext(), \Glueful\Notifications\Services\NotificationService::class);
     foreach ($users as $user) {
-        $stats = $this->getUserStats($user->id);
+        $notifiable = new UserNotifiable($user['uuid'], $user['email']);
+        $stats = $this->getUserStats($user['uuid']);
 
         $notifications->send(
             type: 'digest.weekly',
-            notifiable: $user,
+            notifiable: $notifiable,
             subject: 'Your Weekly Summary',
             data: [
                 'template' => 'weekly-digest',
-                'name' => $user->name,
+                'name' => $user['name'] ?? $user['email'],
                 'stats' => $stats,
-                'highlights' => $this->getHighlights($user->id)
+                'highlights' => $this->getHighlights($user['uuid'])
             ]
         );
     }
@@ -431,7 +448,7 @@ return [
 
 ```php
 // ✅ Good - personal
-"Hi {$user->name}, your order is ready!"
+"Hi {$user['name']}, your order is ready!"
 
 // ❌ Bad - generic
 "Your order is ready."
@@ -463,13 +480,13 @@ Test notifications without sending:
 ```php
 public function testWelcomeEmail()
 {
-    $user = factory(User::class)->create();
+    $notifiable = new \App\Notifications\UserNotifiable('user-uuid', 'user@example.com');
 
-    $result = app(\Glueful\Notifications\Services\NotificationService::class)->send(
+    $result = app($this->getContext(), \Glueful\Notifications\Services\NotificationService::class)->send(
         type: 'user.welcome',
-        notifiable: $user,
+        notifiable: $notifiable,
         subject: 'Welcome!',
-        data: ['template' => 'welcome', 'name' => $user->name]
+        data: ['template' => 'welcome', 'name' => 'Jane Doe']
     );
 
     $this->assertEquals('success', $result['status']);
@@ -504,7 +521,7 @@ class SmsChannel
 {
     public function send($notifiable, $data): array
     {
-        $phone = $notifiable->phone_number;
+        $phone = $notifiable->routeNotificationFor('sms');
         $message = $data['message'];
 
         // Send SMS via provider

--- a/content/3.features/queues-jobs.md
+++ b/content/3.features/queues-jobs.md
@@ -20,7 +20,7 @@ class SendWelcomeEmailJob extends Job
     {
         $data = $this->getData();
         $userId = $data['userId'];
-        $user = db()->table('users')->find($userId);
+        $user = db($context)->table('users')->find($userId);
 
         // Send email
         mail($user->email, 'Welcome!', 'Thanks for joining...');
@@ -34,7 +34,7 @@ class SendWelcomeEmailJob extends Job
 use Glueful\Queue\QueueManager;
 use App\Jobs\SendWelcomeEmailJob;
 
-$queue = service(QueueManager::class);
+$queue = service($context, QueueManager::class);
 $queue->push(SendWelcomeEmailJob::class, ['userId' => $userId]);
 ```
 
@@ -204,7 +204,7 @@ class ImportDataJob extends Job
             throw $e;
         } catch (PermanentException $e) {
             // Don't retry, just log
-            logger()->error('Import failed permanently', [$e]);
+            app($context, \Psr\Log\LoggerInterface::class)->error('Import failed permanently', [$e]);
         }
     }
 }
@@ -344,7 +344,7 @@ class GenerateMonthlyReportJob extends Job
         Storage::put("reports/monthly-{$data['month']}.pdf", $pdf);
 
         // Notify user
-        $queue = service(\Glueful\Queue\QueueManager::class);
+        $queue = service($context, \Glueful\Queue\QueueManager::class);
         $queue->push(NotifyReportReadyJob::class, ['userId' => $data['userId']]);
     }
 }
@@ -356,13 +356,13 @@ Track job metrics:
 
 ```php
 // Queue depth
-$pending = db()->table('queue_jobs')->count();
+$pending = db($context)->table('queue_jobs')->count();
 
 // Failed jobs
-$failed = db()->table('queue_failed_jobs')->count();
+$failed = db($context)->table('queue_failed_jobs')->count();
 
 // Job age
-$oldest = db()->table('queue_jobs')
+$oldest = db($context)->table('queue_jobs')
     ->orderBy('created_at', 'asc')
     ->first();
 ```

--- a/content/3.features/scheduling.md
+++ b/content/3.features/scheduling.md
@@ -166,7 +166,7 @@ Without persistence, jobs are registered in memory for the current process only 
 ```php
 use Glueful\Scheduler\JobScheduler;
 
-$scheduler = app(JobScheduler::class);
+$scheduler = app($context, JobScheduler::class);
 
 $scheduler->register('@hourly', function() {
     // Cleanup task
@@ -189,11 +189,11 @@ class CleanupSessionsJob
     {
         $cutoff = date('Y-m-d H:i:s', strtotime('-30 days'));
 
-        db()->table('sessions')
+        db($context)->table('sessions')
             ->where('last_activity', '<', $cutoff)
             ->delete();
 
-        logger()->info('Cleaned up expired sessions');
+        app($context, \Psr\Log\LoggerInterface::class)->info('Cleaned up expired sessions');
     }
 }
 ```
@@ -216,12 +216,12 @@ class DailyCleanupJob
     public function handle(array $params = []): void
     {
         // Delete old sessions
-        db()->table('sessions')
+        db($context)->table('sessions')
             ->where('created_at', '<', date('Y-m-d', strtotime('-7 days')))
             ->delete();
 
         // Delete old logs
-        db()->table('activity_logs')
+        db($context)->table('activity_logs')
             ->where('created_at', '<', date('Y-m-d', strtotime('-90 days')))
             ->delete();
 
@@ -247,7 +247,7 @@ class WarmCacheJob
     public function handle(array $params = []): void
     {
         // Warm popular product cache
-        $products = db()->table('products')
+        $products = db($context)->table('products')
             ->where('is_featured', true)
             ->get();
 
@@ -274,11 +274,11 @@ class WeeklyReportJob
     public function handle(array $params = []): void
     {
         $stats = [
-            'users' => db()->table('users')->count(),
-            'orders' => db()->table('orders')
+            'users' => db($context)->table('users')->count(),
+            'orders' => db($context)->table('orders')
                 ->where('created_at', '>=', date('Y-m-d', strtotime('-7 days')))
                 ->count(),
-            'revenue' => db()->table('orders')
+            'revenue' => db($context)->table('orders')
                 ->where('created_at', '>=', date('Y-m-d', strtotime('-7 days')))
                 ->sum('total'),
         ];
@@ -316,7 +316,7 @@ class BackupDatabaseJob
         // Upload to S3
         Storage::disk('s3')->put("backups/{$filename}", file_get_contents("{$path}/{$filename}"));
 
-        logger()->info('Database backup completed', ['file' => $filename]);
+        app($context, \Psr\Log\LoggerInterface::class)->info('Database backup completed', ['file' => $filename]);
     }
 }
 ```
@@ -436,9 +436,9 @@ class SendDigestJob
 {
     public function handle(array $params = []): void
     {
-        $users = db()->table('users')->where('digest_enabled', true)->get();
+        $users = db($context)->table('users')->where('digest_enabled', true)->get();
 
-        $queue = service(\Glueful\Queue\QueueManager::class);
+        $queue = service($context, \Glueful\Queue\QueueManager::class);
         foreach ($users as $user) {
             $queue->push(\App\Jobs\SendUserDigestJob::class, ['userId' => $user->id]);
         }
@@ -478,13 +478,13 @@ public function handle(): void
 ```php
 public function handle(): void
 {
-    logger()->info('Starting daily cleanup');
+    app($context, \Psr\Log\LoggerInterface::class)->info('Starting daily cleanup');
 
-    $deleted = db()->table('sessions')
+    $deleted = db($context)->table('sessions')
         ->where('expires_at', '<', now())
         ->delete();
 
-    logger()->info('Daily cleanup completed', [
+    app($context, \Psr\Log\LoggerInterface::class)->info('Daily cleanup completed', [
         'sessions_deleted' => $deleted
     ]);
 }

--- a/content/4.advanced/configuration.md
+++ b/content/4.advanced/configuration.md
@@ -32,18 +32,18 @@ Other useful configs you may encounter:
 
 ## Accessing Configuration
 
-Use the `config()` helper:
+Use the `config($context, ...)` helper:
 
 ```php
 // Get value
-$env = config('app.env');
-$dbHost = config('database.mysql.host');
+$env = config($context, 'app.env');
+$dbHost = config($context, 'database.mysql.host');
 
 // Get with default
-$timeout = config('app.timeout', 30);
+$timeout = config($context, 'app.timeout', 30);
 
 // Get nested value
-$cacheDriver = config('cache.default');
+$cacheDriver = config($context, 'cache.default');
 ```
 
 ## Environment Variables
@@ -155,7 +155,7 @@ return [
     'stores' => [
         'file' => [
             'driver' => 'file',
-            'path' => env('CACHE_FILE_PATH', storage_path('cache')),
+            'path' => env('CACHE_FILE_PATH', storage_path($context, 'cache')),
         ],
 
         'redis' => [
@@ -260,7 +260,7 @@ return [
 ## Configuration Loading & Overrides
 
 Glueful merges framework defaults with your application overrides:
-- The `config()` helper loads framework config first, then application `config/*.php`, using `loadConfigWithHierarchy()`.
+- The `config($context, ...)` helper loads framework config first, then application `config/*.php`, using `loadConfigWithHierarchy()`.
 - Deep merge semantics: associative arrays are merged (app wins), numeric lists are appended and de-duplicated.
 - Use `env()` in config files to make settings environment-aware.
 
@@ -339,11 +339,14 @@ php glueful config:clear
 ],
 ```
 
-Use in code:
+In application code, resolve additional connections through your configured database services or repositories. Do not assume a `db('connection')` helper exists unless you added one in your app:
 
 ```php
-$users = db('mysql_main')->table('users')->get();
-$stats = db('mysql_analytics')->table('stats')->get();
+$mainDb = container($context)->get(\Glueful\Database\Connection::class);
+$users = $mainDb->table('users')->get();
+
+$analytics = app($context, App\Services\AnalyticsStore::class);
+$stats = $analytics->latest();
 ```
 
 ### Multi-Tenant Configuration
@@ -380,7 +383,7 @@ return [
 Use in code:
 
 ```php
-if (config('features.new_dashboard')) {
+if (config($context, 'features.new_dashboard')) {
     return $this->newDashboard();
 }
 
@@ -424,7 +427,7 @@ foreach ($required as $key) {
 'url' => env('APP_URL', 'http://localhost'),
 
 // Then use in code
-$url = config('app.url');
+$url = config($context, 'app.url');
 
 // ❌ Bad - in application code
 $url = env('APP_URL');

--- a/content/4.advanced/dependency-injection.md
+++ b/content/4.advanced/dependency-injection.md
@@ -5,17 +5,19 @@ description: Manage dependencies with the service container
 
 Glueful uses a service container for dependency injection, making your code testable and decoupled.
 
+For standalone examples on this page, assume `$context` is an available `ApplicationContext`. In controllers, prefer constructor injection and `BaseController` helpers over ad hoc container calls.
+
 ## Quick Start
 
 ### Resolving from Container
 
 ```php
 // Get services from the container
-$db = app('database'); // Glueful\\Database\\Connection
-$cache = app(\\Glueful\\Cache\\CacheStore::class);
+$db = app($context, 'database'); // Glueful\\Database\\Connection
+$cache = app($context, \\Glueful\\Cache\\CacheStore::class);
 
 // Convenience alias
-$logger = app(\\Psr\\Log\\LoggerInterface::class); // aliased to 'logger'
+$logger = app($context, \\Psr\\Log\\LoggerInterface::class); // aliased to 'logger'
 ```
 
 ### Constructor Injection
@@ -40,17 +42,21 @@ class UserController
 ### Method Injection
 
 ```php
-class TaskController
+class TaskController extends \Glueful\Controllers\BaseController
 {
     public function store(Request $request, TaskRepository $tasks)
     {
-        $validated = $request->validate([
-            'title' => 'required|string',
-        ]);
+        $data = $this->getRequestData();
 
-        $task = $tasks->create($validated);
+        if ($error = $this->validateRequest($data, [
+            'title' => 'required|max:255',
+        ])) {
+            return $error;
+        }
 
-        return Response::success($task, 201);
+        $task = $tasks->create($data);
+
+        return $this->created($task);
     }
 }
 ```
@@ -77,7 +83,7 @@ final class AppServiceProvider extends BaseServiceProvider
             // Factory-built services
             'report.generator' => new FactoryDefinition(
                 'report.generator',
-                fn() => new App\Services\ReportGenerator(config('app'))
+                fn() => new App\Services\ReportGenerator(config($this->getContext(), 'app'))
             ),
 
             // Aliases (map type-hints to existing ids)
@@ -105,7 +111,7 @@ class OrderService
 }
 
 // Container resolves dependencies
-$orderService = app(OrderService::class);
+$orderService = app($context, OrderService::class);
 ```
 
 ### Type-Hinted Parameters
@@ -249,8 +255,8 @@ class OrderController
 {
     public function store(Request $request, OrderService $orders)
     {
-        $order = $orders->createOrder($request->all());
-        return Response::success($order, 201);
+        $order = $orders->createOrder($request->toArray());
+        return Response::created($order);
     }
 }
 ```
@@ -342,9 +348,9 @@ class UserControllerTest extends TestCase
         parent::setUp();
 
         // Replace real repository with mock
-        app()->bind(UserRepositoryInterface::class, function () {
-            return new FakeUserRepository();
-        });
+        container($context)->load([
+            UserRepositoryInterface::class => fn() => new FakeUserRepository(),
+        ]);
     }
 
     public function test_lists_users()
@@ -403,7 +409,7 @@ class TaskService
 {
     public function create(array $data)
     {
-        $task = db()->table('tasks')->create($data);
+        $task = db($context)->table('tasks')->create($data);
         event(new TaskCreated($task));
         return $task;
     }
@@ -479,14 +485,14 @@ if ($container->isShared('service')) {
 
 ```php
 // Get container instance
-$container = app();
+$container = container($context);
 
 // Resolve service by id or class
-$db = app('database');
-$cache = app(\Glueful\Cache\CacheStore::class);
+$db = app($context, 'database');
+$cache = app($context, \Glueful\Cache\CacheStore::class);
 
-// Convenience helper (same as app())
-$queue = service(\Glueful\Queue\QueueManager::class);
+// Convenience helper
+$queue = service($context, \Glueful\Queue\QueueManager::class);
 ```
 
 ## Built-in Aliases
@@ -494,14 +500,14 @@ $queue = service(\Glueful\Queue\QueueManager::class);
 Common container ids and class aliases registered by core providers:
 
 - 'logger' → \Psr\Log\LoggerInterface
-  - Resolve with: app('logger') or app(\Psr\Log\LoggerInterface::class)
+  - Resolve with: app($context, 'logger') or app($context, \Psr\Log\LoggerInterface::class)
 - 'database' → \Glueful\Database\Connection
-  - Resolve with: app('database')
+  - Resolve with: app($context, 'database')
   - Also available: \Glueful\Database\QueryBuilder::class, \Glueful\Database\Schema\Interfaces\SchemaBuilderInterface::class
 - 'cache.store' → \Glueful\Cache\CacheStore
-  - Resolve with: app('cache.store') or app(\Glueful\Cache\CacheStore::class)
+  - Resolve with: app($context, 'cache.store') or app($context, \Glueful\Cache\CacheStore::class)
 - 'request' → \Symfony\Component\HttpFoundation\Request (from globals)
-- Queue manager (class-based): \Glueful\Queue\QueueManager via service()/app()
+- Queue manager (class-based): `\Glueful\Queue\QueueManager` via `service($context, \Glueful\Queue\QueueManager::class)` or `app($context, \Glueful\Queue\QueueManager::class)`
 
 Note: Exact registrations can vary with environment and extensions. Check config/serviceproviders.php, config/extensions.php, and the provider classes for full lists.
 
@@ -560,7 +566,7 @@ final class AppServiceProvider extends BaseServiceProvider
             // Factory-built service with config
             'reports.exporter' => new FactoryDefinition(
                 'reports.exporter',
-                fn() => new App\Services\Exporter(config('app.urls'))
+                fn() => new App\Services\Exporter(config($this->getContext(), 'app.urls'))
             ),
 
             // Alias a type-hint to an id
@@ -584,8 +590,8 @@ return [
 3) Resolve anywhere:
 
 ```php
-$reports = app(App\Services\ReportService::class);
-$exporter = app(App\Contracts\ExporterInterface::class); // resolves to 'reports.exporter'
+$reports = app($context, App\Services\ReportService::class);
+$exporter = app($context, App\Contracts\ExporterInterface::class); // resolves to 'reports.exporter'
 ```
 
 ## Troubleshooting

--- a/content/4.advanced/middleware.md
+++ b/content/4.advanced/middleware.md
@@ -117,7 +117,7 @@ class RequestLoggingMiddleware implements RouteMiddleware
 {
     public function handle(Request $request, callable $next): mixed
     {
-        logger()->info('Request started', [
+        app($context, \Psr\Log\LoggerInterface::class)->info('Request started', [
             'method' => $request->getMethod(),
             'uri' => $request->getRequestUri(),
             'ip' => $request->getClientIp(),
@@ -125,7 +125,7 @@ class RequestLoggingMiddleware implements RouteMiddleware
 
         $response = $next($request);
 
-        logger()->info('Request completed', [
+        app($context, \Psr\Log\LoggerInterface::class)->info('Request completed', [
             'status' => $response->getStatusCode(),
         ]);
 
@@ -281,7 +281,7 @@ class MaintenanceModeMiddleware implements RouteMiddleware
 {
     public function handle(Request $request, callable $next): mixed
     {
-        if (config('app.maintenance_mode') && !$this->isWhitelisted($request)) {
+        if (config($context, 'app.maintenance_mode') && !$this->isWhitelisted($request)) {
             return Response::error('Service under maintenance', 503);
         }
 
@@ -290,7 +290,7 @@ class MaintenanceModeMiddleware implements RouteMiddleware
 
     private function isWhitelisted(Request $request): bool
     {
-        $whitelistedIps = config('app.maintenance_whitelist', []);
+        $whitelistedIps = config($context, 'app.maintenance_whitelist', []);
         return in_array($request->getClientIp(), $whitelistedIps);
     }
 }

--- a/content/4.advanced/performance.md
+++ b/content/4.advanced/performance.md
@@ -11,9 +11,9 @@ Optimize your application for speed, efficiency, and scalability.
 
 ```php
 // Cache expensive queries
-$cache = app(\Glueful\Cache\CacheStore::class);
+$cache = app($context, \Glueful\Cache\CacheStore::class);
 $users = $cache->remember('users:active', function() {
-    return app('database')
+    return app($context, 'database')
         ->table('users')
         ->where('status', 'active')
         ->get();
@@ -35,7 +35,7 @@ $schema->table('posts', function($table) {
 
 ```php
 // Don't process inline
-$queue = service(\Glueful\Queue\QueueManager::class);
+$queue = service($context, \Glueful\Queue\QueueManager::class);
 $queue->push(\App\Jobs\ProcessImageJob::class, ['path' => $path]);
 $queue->push(\App\Jobs\SendEmailJob::class, ['userId' => $userId]);
 ```
@@ -46,25 +46,25 @@ $queue->push(\App\Jobs\SendEmailJob::class, ['userId' => $userId]);
 
 ```php
 // ✅ Good - specific columns
-$users = app('database')->table('users')
+$users = app($context, 'database')->table('users')
     ->select(['id', 'name', 'email'])
     ->get();
 
 // ❌ Bad - all columns
-$users = app('database')->table('users')->get();
+$users = app($context, 'database')->table('users')->get();
 ```
 
 ### Avoid N+1 Queries
 
 ```php
 // ❌ Bad - N+1 query problem
-$posts = app('database')->table('posts')->get();
+$posts = app($context, 'database')->table('posts')->get();
 foreach ($posts as $post) {
-    $user = app('database')->table('users')->find($post->user_id); // Query per post!
+    $user = app($context, 'database')->table('users')->find($post->user_id); // Query per post!
 }
 
 // ✅ Good - join or eager load
-$posts = app('database')->table('posts')
+$posts = app($context, 'database')->table('posts')
     ->join('users', 'posts.user_id', '=', 'users.id')
     ->select(['posts.*', 'users.name as author_name'])
     ->get();
@@ -75,11 +75,11 @@ $posts = app('database')->table('posts')
 ```php
 // ❌ Bad - individual inserts
 foreach ($users as $user) {
-    app('database')->table('users')->insert($user);
+    app($context, 'database')->table('users')->insert($user);
 }
 
 // ✅ Good - batch insert
-app('database')->table('users')->insertMany($users);
+app($context, 'database')->table('users')->insertMany($users);
 ```
 
 ### Add Database Indexes
@@ -103,7 +103,7 @@ $table->index(['status', 'created_at']);
 public function getActiveUsers()
 {
     return Cache::remember('users:active', function() {
-        return db()->table('users')
+        return db($context)->table('users')
             ->where('status', 'active')
             ->get();
     }, 3600);
@@ -128,9 +128,9 @@ public function getStatistics()
 {
     return Cache::remember('stats:dashboard', function() {
         return [
-            'users' => db()->table('users')->count(),
-            'posts' => db()->table('posts')->count(),
-            'revenue' => db()->table('orders')->sum('total'),
+            'users' => db($context)->table('users')->count(),
+            'posts' => db($context)->table('posts')->count(),
+            'revenue' => db($context)->table('orders')->sum('total'),
         ];
     }, 300);
 }
@@ -148,7 +148,7 @@ Cache::deletePattern('users:*');
 // Clear on update
 public function update($id, $data)
 {
-    db()->table('users')->where('id', $id)->update($data);
+    db($context)->table('users')->where('id', $id)->update($data);
 
     // Invalidate cache
     Cache::delete('users:active');
@@ -173,12 +173,12 @@ Check for:
 
 ```php
 // ✅ Good - join on indexed columns
-$posts = app('database')->table('posts')
+$posts = app($context, 'database')->table('posts')
     ->join('users', 'posts.user_id', '=', 'users.id')
     ->get();
 
 // ❌ Bad - join on non-indexed columns
-$posts = app('database')->table('posts')
+$posts = app($context, 'database')->table('posts')
     ->join('users', 'posts.author_name', '=', 'users.name')
     ->get();
 ```
@@ -187,23 +187,23 @@ $posts = app('database')->table('posts')
 
 ```php
 // ✅ Good - paginated
-$posts = app('database')->table('posts')
+$posts = app($context, 'database')->table('posts')
     ->limit(20)
     ->offset(($page - 1) * 20)
     ->get();
 
 // ❌ Bad - load everything
-$posts = app('database')->table('posts')->get();
+$posts = app($context, 'database')->table('posts')->get();
 ```
 
 ### Count Efficiently
 
 ```php
 // ✅ Good - database count
-$count = app('database')->table('users')->count();
+$count = app($context, 'database')->table('users')->count();
 
 // ❌ Bad - load all then count
-$count = count(app('database')->table('users')->get());
+$count = count(app($context, 'database')->table('users')->get());
 ```
 
 ## Response Optimization
@@ -255,7 +255,7 @@ foreach ($orders as $order) {
 }
 
 // ✅ Good - database aggregation
-$total = app('database')->table('orders')->sum('amount');
+$total = app($context, 'database')->table('orders')->sum('amount');
 ```
 
 ### Use Lazy Loading
@@ -267,7 +267,7 @@ public function getUser($id)
     static $user;
 
     if (!$user) {
-        $user = app('database')->table('users')->find($id);
+        $user = app($context, 'database')->table('users')->find($id);
     }
 
     return $user;
@@ -295,7 +295,7 @@ for ($i = 0; $i < $length; $i++) {
 
 ```php
 // ❌ Bad - load all at once
-$users = app('database')->table('users')->get();
+$users = app($context, 'database')->table('users')->get();
 foreach ($users as $user) {
     // Process...
 }
@@ -303,7 +303,7 @@ foreach ($users as $user) {
 // ✅ Good - process in batches with limit/offset
 $batchSize = 1000;
 for ($offset = 0; ; $offset += $batchSize) {
-    $batch = app('database')->table('users')->limit($batchSize)->offset($offset)->get();
+    $batch = app($context, 'database')->table('users')->limit($batchSize)->offset($offset)->get();
     if (count($batch) === 0) {
         break;
     }
@@ -347,7 +347,7 @@ $start = microtime(true);
 // Code to profile
 
 $duration = microtime(true) - $start;
-logger()->info('Execution time: ' . $duration . 's');
+app($context, \Psr\Log\LoggerInterface::class)->info('Execution time: ' . $duration . 's');
 ```
 
 ### Profile Queries
@@ -355,9 +355,9 @@ logger()->info('Execution time: ' . $duration . 's');
 ```php
 $start = microtime(true);
 
-$users = db()->table('users')->get();
+$users = db($context)->table('users')->get();
 
-logger()->info('Query time: ' . (microtime(true) - $start) . 's');
+app($context, \Psr\Log\LoggerInterface::class)->info('Query time: ' . (microtime(true) - $start) . 's');
 ```
 
 ### Memory Usage
@@ -370,7 +370,7 @@ $memoryBefore = memory_get_usage();
 $memoryAfter = memory_get_usage();
 $memoryUsed = $memoryAfter - $memoryBefore;
 
-logger()->info('Memory used: ' . ($memoryUsed / 1024 / 1024) . ' MB');
+app($context, \Psr\Log\LoggerInterface::class)->info('Memory used: ' . ($memoryUsed / 1024 / 1024) . ' MB');
 ```
 
 ## Monitoring
@@ -388,7 +388,7 @@ Track these metrics:
 ### Logging
 
 ```php
-logger()->info('Request processed', [
+app($context, \Psr\Log\LoggerInterface::class)->info('Request processed', [
     'duration' => $duration,
     'memory' => memory_get_peak_usage(true),
     'queries' => $queryCount,

--- a/content/4.advanced/repositories.md
+++ b/content/4.advanced/repositories.md
@@ -337,9 +337,9 @@ $uow->registerRemoved('comments', $commentUuid);
 // Commit all changes atomically
 try {
     $result = $uow->commit();
-    logger()->info('Transaction committed', ['changes' => $result]);
+    app($context, \Psr\Log\LoggerInterface::class)->info('Transaction committed', ['changes' => $result]);
 } catch (\Exception $e) {
-    logger()->error('Transaction failed', ['error' => $e->getMessage()]);
+    app($context, \Psr\Log\LoggerInterface::class)->error('Transaction failed', ['error' => $e->getMessage()]);
     throw $e;
 }
 ```
@@ -388,7 +388,7 @@ Centralize repository instantiation:
 use Glueful\Repository\RepositoryFactory;
 
 // Recommended: resolve from container
-$factory = app(RepositoryFactory::class); // or service('repository')
+$factory = app($context, RepositoryFactory::class); // or service($context, 'repository')
 
 // Get specific repository (typed helper)
 $users = $factory->users();
@@ -410,7 +410,7 @@ use Glueful\Events\EntityUpdatedEvent;
 
 // Listen to repository events
 Event::listen(EntityCreatedEvent::class, function ($event) {
-    logger()->info('Entity created', [
+    app($context, \Psr\Log\LoggerInterface::class)->info('Entity created', [
         'table' => $event->table,
         'uuid' => $event->uuid,
     ]);
@@ -420,7 +420,7 @@ Event::listen(EntityCreatedEvent::class, function ($event) {
 });
 
 Event::listen(EntityUpdatedEvent::class, function ($event) {
-    logger()->info('Entity updated', [
+    app($context, \Psr\Log\LoggerInterface::class)->info('Entity updated', [
         'table' => $event->table,
         'uuid' => $event->uuid,
     ]);

--- a/content/4.advanced/service-providers.md
+++ b/content/4.advanced/service-providers.md
@@ -31,7 +31,7 @@ final class AppServiceProvider extends BaseServiceProvider
             // Factory with config
             'payment.gateway' => new FactoryDefinition(
                 'payment.gateway',
-                fn() => new App\Payments\StripePaymentGateway(config('services.stripe'))
+                fn() => new App\Payments\StripePaymentGateway(config($context, 'services.stripe'))
             ),
 
             // Alias interface to id
@@ -145,7 +145,7 @@ final class CacheServiceProvider extends BaseServiceProvider
 Resolve the manager as needed:
 
 ```php
-$queue = app(\Glueful\Queue\QueueManager::class);
+$queue = app($context, \Glueful\Queue\QueueManager::class);
 $queue->push(App\Jobs\SendEmail::class, ['userId' => $id]);
 ```
 
@@ -365,13 +365,15 @@ class UserServiceTest extends TestCase
         parent::setUp();
 
         // Replace provider bindings
-        app()->bind(EmailService::class, FakeEmailService::class);
-        app()->bind(PaymentGateway::class, FakePaymentGateway::class);
+        container($context)->load([
+            EmailService::class => fn() => new FakeEmailService(),
+            PaymentGateway::class => fn() => new FakePaymentGateway(),
+        ]);
     }
 
     public function test_creates_user()
     {
-        $service = app(UserService::class);
+        $service = app($context, UserService::class);
         $user = $service->create(['email' => 'test@example.com']);
 
         $this->assertNotNull($user);
@@ -390,10 +392,12 @@ class OrderServiceTest extends TestCase
         $gateway = $this->createMock(PaymentGateway::class);
         $gateway->method('charge')->willReturn(['status' => 'success']);
 
-        app()->instance(PaymentGateway::class, $gateway);
+        container($context)->load([
+            PaymentGateway::class => fn() => $gateway,
+        ]);
 
         // Test
-        $service = app(OrderService::class);
+        $service = app($context, OrderService::class);
         $order = $service->processOrder($orderData);
 
         $this->assertEquals('completed', $order->status);

--- a/content/4.advanced/testing.md
+++ b/content/4.advanced/testing.md
@@ -32,8 +32,8 @@ tests/
 
 ## Testing Helpers
 
-- `app()` and `service()` resolve services from the DI container in tests.
-- `container()` returns the PSR‑11 container (useful for constructing Router).
+- `app($context, Service::class)` and `service($context, Service::class)` resolve services from the DI container in tests.
+- `container($context)` returns the PSR‑11 container (useful for constructing Router).
 - Extend `Glueful\Testing\TestCase` to bootstrap a minimal application per test class.
 
 Example using the base test case:
@@ -48,15 +48,15 @@ final class UsersRepositoryTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repoFactory = app(\Glueful\Repository\RepositoryFactory::class);
+        $this->repoFactory = app($context, \Glueful\Repository\RepositoryFactory::class);
         // Optional: start transaction
-        app('database')->getPDO()->beginTransaction();
+        app($context, 'database')->getPDO()->beginTransaction();
     }
 
     protected function tearDown(): void
     {
         // Optional: rollback
-        app('database')->getPDO()->rollBack();
+        app($context, 'database')->getPDO()->rollBack();
         parent::tearDown();
     }
 
@@ -126,7 +126,7 @@ class UserRepositoryTest extends TestCase
     protected function setUp(): void
     {
         // Setup test database
-        $this->db = app('database');
+        $this->db = app($context, 'database');
         $this->userRepo = new UserRepository($this->db);
 
         // Start transaction
@@ -188,7 +188,7 @@ final class AuthenticationTest extends TestCase
 {
     public function test_user_can_register(): void
     {
-        $router = new Router(container()); // or construct with a minimal PSR‑11 container
+        $router = new Router(container($context)); // or construct with a minimal PSR‑11 container
         // register routes here or load your app routes
 
         $request = Request::create('/auth/register', 'POST', [
@@ -215,7 +215,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 public function test_returns_json_payload(): void
 {
-    $router = new Router(container());
+    $router = new Router(container($context));
 
     // Minimal route for test
     $router->get('/ping', fn() => \Glueful\Http\Response::success(['pong' => true]));

--- a/content/5.deployment/docker.md
+++ b/content/5.deployment/docker.md
@@ -462,7 +462,6 @@ spec:
           name: glueful-nginx
       - name: public
         emptyDir: {}
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/content/5.deployment/logging.md
+++ b/content/5.deployment/logging.md
@@ -11,11 +11,11 @@ Implement effective logging strategies for debugging, monitoring, and auditing y
 
 ```php
 // Log messages at different levels
-logger()->debug('Debugging info', ['user_id' => 123]);
-logger()->info('User registered', ['email' => 'john@example.com']);
-logger()->warning('Cache miss', ['key' => 'users:active']);
-logger()->error('Payment failed', ['order_id' => 'abc123', 'error' => $e->getMessage()]);
-logger()->critical('Database connection lost');
+app($context, \Psr\Log\LoggerInterface::class)->debug('Debugging info', ['user_id' => 123]);
+app($context, \Psr\Log\LoggerInterface::class)->info('User registered', ['email' => 'john@example.com']);
+app($context, \Psr\Log\LoggerInterface::class)->warning('Cache miss', ['key' => 'users:active']);
+app($context, \Psr\Log\LoggerInterface::class)->error('Payment failed', ['order_id' => 'abc123', 'error' => $e->getMessage()]);
+app($context, \Psr\Log\LoggerInterface::class)->critical('Database connection lost');
 ```
 
 ### Structured Logging
@@ -23,7 +23,7 @@ logger()->critical('Database connection lost');
 Always include context:
 
 ```php
-logger()->info('Order created', [
+app($context, \Psr\Log\LoggerInterface::class)->info('Order created', [
     'order_id' => $order->id,
     'user_id' => $order->user_id,
     'total' => $order->total,
@@ -38,12 +38,12 @@ Log to a specific channel (e.g., `api`, `app`, `framework`):
 
 ```php
 // If your app exposes the LogManager via helper
-logger()->channel('api')->info('API request', ['path' => $request->path()]);
+app($context, \Psr\Log\LoggerInterface::class)->channel('api')->info('API request', ['path' => $request->path()]);
 
 // Or via the container/DI
 use Glueful\Logging\LogManager;
 /** @var LogManager $log */
-$log = container()->get(LogManager::class);
+$log = container($context)->get(LogManager::class);
 $log->channel('framework')->warning('Slow request', ['duration_ms' => 1250]);
 ```
 
@@ -125,27 +125,27 @@ Default files under `storage/logs/`:
 
 ```php
 // DEBUG - Development debugging only
-logger()->debug('SQL query executed', [
+app($context, \Psr\Log\LoggerInterface::class)->debug('SQL query executed', [
     'sql' => $sql,
     'bindings' => $bindings,
     'duration' => $duration,
 ]);
 
 // INFO - Significant events
-logger()->info('User logged in', [
+app($context, \Psr\Log\LoggerInterface::class)->info('User logged in', [
     'user_id' => $user->id,
     'ip' => $request->ip(),
 ]);
 
 // WARNING - Unexpected but handled situations
-logger()->warning('API rate limit approaching', [
+app($context, \Psr\Log\LoggerInterface::class)->warning('API rate limit approaching', [
     'user_id' => $user->id,
     'requests' => $count,
     'limit' => $limit,
 ]);
 
 // ERROR - Runtime errors that need attention
-logger()->error('External API failed', [
+app($context, \Psr\Log\LoggerInterface::class)->error('External API failed', [
     'service' => 'stripe',
     'endpoint' => '/charges',
     'error' => $exception->getMessage(),
@@ -153,8 +153,8 @@ logger()->error('External API failed', [
 ]);
 
 // CRITICAL - System failures requiring immediate action
-logger()->critical('Database connection failed', [
-    'host' => config('database.host'),
+app($context, \Psr\Log\LoggerInterface::class)->critical('Database connection failed', [
+    'host' => config($context, 'database.host'),
     'error' => $exception->getMessage(),
 ]);
 ```
@@ -178,7 +178,7 @@ class LogContextMiddleware
         ];
 
         // Add context to all subsequent logs
-        logger()->withContext($context);
+        app($context, \Psr\Log\LoggerInterface::class)->withContext($context);
 
         return $next($request);
     }
@@ -188,7 +188,7 @@ class LogContextMiddleware
 ### Application Context
 
 ```php
-logger()->info('Processing job', [
+app($context, \Psr\Log\LoggerInterface::class)->info('Processing job', [
     'job' => get_class($job),
     'queue' => $queue,
     'attempt' => $attempt,
@@ -207,7 +207,7 @@ class ApiLoggingMiddleware
     {
         $start = microtime(true);
 
-        logger()->info('API request started', [
+        app($context, \Psr\Log\LoggerInterface::class)->info('API request started', [
             'method' => $request->method(),
             'path' => $request->path(),
             'query' => $request->query(),
@@ -215,7 +215,7 @@ class ApiLoggingMiddleware
 
         $response = $next($request);
 
-        logger()->info('API request completed', [
+        app($context, \Psr\Log\LoggerInterface::class)->info('API request completed', [
             'method' => $request->method(),
             'path' => $request->path(),
             'status' => $response->getStatusCode(),
@@ -235,15 +235,15 @@ class QueryLogger
     public function log(string $sql, array $bindings, float $duration): void
     {
         if ($duration > 1.0) {
-            logger()->warning('Slow query detected', [
+            app($context, \Psr\Log\LoggerInterface::class)->warning('Slow query detected', [
                 'sql' => $sql,
                 'bindings' => $bindings,
                 'duration' => $duration . 's',
             ]);
         }
 
-        if (config('app.debug')) {
-            logger()->debug('Query executed', [
+        if (config($context, 'app.debug')) {
+            app($context, \Psr\Log\LoggerInterface::class)->debug('Query executed', [
                 'sql' => $sql,
                 'bindings' => $bindings,
                 'duration' => $duration . 's',
@@ -260,7 +260,7 @@ class ProcessOrderJob extends Job
 {
     public function handle(): void
     {
-        logger()->info('Processing order', [
+        app($context, \Psr\Log\LoggerInterface::class)->info('Processing order', [
             'order_id' => $this->orderId,
             'job_id' => $this->job->id(),
         ]);
@@ -268,11 +268,11 @@ class ProcessOrderJob extends Job
         try {
             $this->processOrder();
 
-            logger()->info('Order processed successfully', [
+            app($context, \Psr\Log\LoggerInterface::class)->info('Order processed successfully', [
                 'order_id' => $this->orderId,
             ]);
         } catch (\Exception $e) {
-            logger()->error('Order processing failed', [
+            app($context, \Psr\Log\LoggerInterface::class)->error('Order processing failed', [
                 'order_id' => $this->orderId,
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
@@ -288,21 +288,21 @@ class ProcessOrderJob extends Job
 
 ```php
 // Successful login
-logger()->info('User logged in', [
+app($context, \Psr\Log\LoggerInterface::class)->info('User logged in', [
     'user_id' => $user->id,
     'email' => $user->email,
     'ip' => $request->ip(),
 ]);
 
 // Failed login
-logger()->warning('Failed login attempt', [
+app($context, \Psr\Log\LoggerInterface::class)->warning('Failed login attempt', [
     'email' => $request->input('email'),
     'ip' => $request->ip(),
     'reason' => 'invalid_credentials',
 ]);
 
 // Account lockout
-logger()->critical('Account locked', [
+app($context, \Psr\Log\LoggerInterface::class)->critical('Account locked', [
     'user_id' => $user->id,
     'failed_attempts' => $attempts,
 ]);
@@ -388,12 +388,12 @@ class ElasticsearchLogger
             'level' => $level,
             'message' => $message,
             'context' => $context,
-            'app' => config('app.name'),
-            'env' => config('app.env'),
+            'app' => config($context, 'app.name'),
+            'env' => config($context, 'app.env'),
         ];
 
         $client = new \Elasticsearch\Client([
-            'hosts' => [config('logging.elasticsearch.host')],
+            'hosts' => [config($context, 'logging.elasticsearch.host')],
         ]);
 
         $client->index([
@@ -423,7 +423,7 @@ class SecureLogger
     public function log(string $level, string $message, array $context = []): void
     {
         $context = $this->redactSensitiveData($context);
-        logger()->log($level, $message, $context);
+        app($context, \Psr\Log\LoggerInterface::class)->log($level, $message, $context);
     }
 
     private function redactSensitiveData(array $data): array
@@ -490,7 +490,7 @@ class LogMessageJob extends Job
 
     public function handle(): void
     {
-        logger()->log($this->level, $this->message, $this->context);
+        app($context, \Psr\Log\LoggerInterface::class)->log($this->level, $this->message, $this->context);
     }
 }
 ```
@@ -515,7 +515,7 @@ class BufferedLogger
     public function flush(): void
     {
         foreach ($this->buffer as [$level, $message, $context]) {
-            logger()->log($level, $message, $context);
+            app($context, \Psr\Log\LoggerInterface::class)->log($level, $message, $context);
         }
 
         $this->buffer = [];
@@ -540,8 +540,8 @@ LOG_LEVEL=debug
 ### Debug Specific Components
 
 ```php
-if (config('app.debug')) {
-    logger()->debug('Cache operation', [
+if (config($context, 'app.debug')) {
+    app($context, \Psr\Log\LoggerInterface::class)->debug('Cache operation', [
         'operation' => 'get',
         'key' => $key,
         'hit' => $hit,
@@ -554,13 +554,13 @@ if (config('app.debug')) {
 
 ```php
 // Log only in specific environments
-if (in_array(config('app.env'), ['development', 'staging'])) {
-    logger()->debug('Development log', $data);
+if (in_array(config($context, 'app.env'), ['development', 'staging'])) {
+    app($context, \Psr\Log\LoggerInterface::class)->debug('Development log', $data);
 }
 
 // Log only for specific users
 if ($request->user()?->is_admin) {
-    logger()->info('Admin action', ['action' => $action]);
+    app($context, \Psr\Log\LoggerInterface::class)->info('Admin action', ['action' => $action]);
 }
 ```
 
@@ -570,49 +570,49 @@ if ($request->user()?->is_admin) {
 
 ```php
 // ✅ Good - correct levels
-logger()->info('User registered');  // Normal event
-logger()->error('Payment failed'); // Error condition
+app($context, \Psr\Log\LoggerInterface::class)->info('User registered');  // Normal event
+app($context, \Psr\Log\LoggerInterface::class)->error('Payment failed'); // Error condition
 
 // ❌ Bad - wrong levels
-logger()->error('User registered');  // Not an error
-logger()->info('Database crashed');  // Too severe
+app($context, \Psr\Log\LoggerInterface::class)->error('User registered');  // Not an error
+app($context, \Psr\Log\LoggerInterface::class)->info('Database crashed');  // Too severe
 ```
 
 ### 2. Include Context
 
 ```php
 // ✅ Good - rich context
-logger()->error('Order failed', [
+app($context, \Psr\Log\LoggerInterface::class)->error('Order failed', [
     'order_id' => $order->id,
     'user_id' => $user->id,
     'error' => $e->getMessage(),
 ]);
 
 // ❌ Bad - no context
-logger()->error('Order failed');
+app($context, \Psr\Log\LoggerInterface::class)->error('Order failed');
 ```
 
 ### 3. Be Consistent
 
 ```php
 // ✅ Good - consistent format
-logger()->info('User action', ['action' => 'login', 'user_id' => 123]);
-logger()->info('User action', ['action' => 'logout', 'user_id' => 123]);
+app($context, \Psr\Log\LoggerInterface::class)->info('User action', ['action' => 'login', 'user_id' => 123]);
+app($context, \Psr\Log\LoggerInterface::class)->info('User action', ['action' => 'logout', 'user_id' => 123]);
 
 // ❌ Bad - inconsistent
-logger()->info('User logged in', ['user' => 123]);
-logger()->info('Logout: 123');
+app($context, \Psr\Log\LoggerInterface::class)->info('User logged in', ['user' => 123]);
+app($context, \Psr\Log\LoggerInterface::class)->info('Logout: 123');
 ```
 
 ### 4. Avoid Excessive Logging
 
 ```php
 // ✅ Good - meaningful logs
-logger()->info('Batch processed', ['count' => 1000]);
+app($context, \Psr\Log\LoggerInterface::class)->info('Batch processed', ['count' => 1000]);
 
 // ❌ Bad - noisy
 foreach ($items as $item) {
-    logger()->info('Processing item', ['id' => $item->id]);
+    app($context, \Psr\Log\LoggerInterface::class)->info('Processing item', ['id' => $item->id]);
 }
 ```
 

--- a/content/5.deployment/monitoring.md
+++ b/content/5.deployment/monitoring.md
@@ -87,7 +87,7 @@ class MetricsMiddleware
         $memoryUsed = memory_get_usage() - $memoryStart;
 
         // Log metrics
-        logger()->info('Request completed', [
+        app($context, \Psr\Log\LoggerInterface::class)->info('Request completed', [
             'method' => $request->method(),
             'path' => $request->path(),
             'status' => $response->getStatusCode(),
@@ -124,11 +124,11 @@ class DatabaseMetrics
         $start = microtime(true);
 
         // Run test query
-        db()->table('users')->limit(1)->get();
+        db($context)->table('users')->limit(1)->get();
 
         return [
             'response_time' => microtime(true) - $start,
-            'connections' => db()->getConnectionCount(),
+            'connections' => db($context)->getConnectionCount(),
         ];
     }
 }
@@ -145,7 +145,7 @@ class QueueMetrics
 {
     public static function depth(string $queue = 'default'): int
     {
-        $prefix = config('queue.connections.redis.prefix', 'glueful:queue:');
+        $prefix = config($context, 'queue.connections.redis.prefix', 'glueful:queue:');
         $immediate = redis()->lLen("{$prefix}queue:{$queue}");
         $delayed = redis()->zCard("{$prefix}queue:{$queue}:delayed");
         $reserved = redis()->zCard("{$prefix}queue:{$queue}:reserved");
@@ -154,7 +154,7 @@ class QueueMetrics
 
     public static function failed(): int
     {
-        return db()->table('queue_failed_jobs')->count();
+        return db($context)->table('queue_failed_jobs')->count();
     }
 }
 ```
@@ -164,7 +164,7 @@ class QueueMetrics
 ### Structured Logging
 
 ```php
-logger()->info('Order processed', [
+app($context, \Psr\Log\LoggerInterface::class)->info('Order processed', [
     'order_id' => $order->id,
     'user_id' => $order->user_id,
     'total' => $order->total,
@@ -172,7 +172,7 @@ logger()->info('Order processed', [
     'payment_method' => $order->payment_method,
 ]);
 
-logger()->error('Payment failed', [
+app($context, \Psr\Log\LoggerInterface::class)->error('Payment failed', [
     'order_id' => $order->id,
     'error' => $exception->getMessage(),
     'gateway_response' => $gatewayResponse,
@@ -183,19 +183,19 @@ logger()->error('Payment failed', [
 
 ```php
 // DEBUG - Development debugging
-logger()->debug('Query executed', ['sql' => $sql, 'bindings' => $bindings]);
+app($context, \Psr\Log\LoggerInterface::class)->debug('Query executed', ['sql' => $sql, 'bindings' => $bindings]);
 
 // INFO - Significant events
-logger()->info('User registered', ['user_id' => $user->id]);
+app($context, \Psr\Log\LoggerInterface::class)->info('User registered', ['user_id' => $user->id]);
 
 // WARNING - Unusual but handled
-logger()->warning('Cache miss', ['key' => $cacheKey]);
+app($context, \Psr\Log\LoggerInterface::class)->warning('Cache miss', ['key' => $cacheKey]);
 
 // ERROR - Errors that need attention
-logger()->error('API call failed', ['service' => 'stripe', 'error' => $e]);
+app($context, \Psr\Log\LoggerInterface::class)->error('API call failed', ['service' => 'stripe', 'error' => $e]);
 
 // CRITICAL - System failures
-logger()->critical('Database connection lost');
+app($context, \Psr\Log\LoggerInterface::class)->critical('Database connection lost');
 ```
 
 ## Error Tracking
@@ -208,7 +208,7 @@ class ExceptionHandler
     public function report(\Throwable $exception): void
     {
         // Log locally
-        logger()->error($exception->getMessage(), [
+        app($context, \Psr\Log\LoggerInterface::class)->error($exception->getMessage(), [
             'exception' => get_class($exception),
             'file' => $exception->getFile(),
             'line' => $exception->getLine(),
@@ -216,7 +216,7 @@ class ExceptionHandler
         ]);
 
         // Send to error tracking service (Sentry, Bugsnag, etc.)
-        if (config('app.env') === 'production') {
+        if (config($context, 'app.env') === 'production') {
             $this->reportToSentry($exception);
         }
     }
@@ -233,7 +233,7 @@ class ExceptionHandler
 
 ```php
 // Business metrics
-logger()->info('Subscription purchased', [
+app($context, \Psr\Log\LoggerInterface::class)->info('Subscription purchased', [
     'plan' => 'pro',
     'revenue' => 99.00,
     'user_id' => $user->id,
@@ -241,7 +241,7 @@ logger()->info('Subscription purchased', [
 
 // Performance issues
 if ($duration > 5.0) {
-    logger()->warning('Slow query detected', [
+    app($context, \Psr\Log\LoggerInterface::class)->warning('Slow query detected', [
         'query' => $sql,
         'duration' => $duration,
     ]);
@@ -285,7 +285,7 @@ class AlertService
     private function alert(string $message): void
     {
         // Send to Slack, PagerDuty, etc.
-        logger()->critical($message);
+        app($context, \Psr\Log\LoggerInterface::class)->critical($message);
 
         // Example: Slack webhook
         $this->sendToSlack($message);
@@ -293,7 +293,7 @@ class AlertService
 
     private function sendToSlack(string $message): void
     {
-        $webhook = config('monitoring.slack_webhook');
+        $webhook = config($context, 'monitoring.slack_webhook');
 
         $ch = curl_init($webhook);
         curl_setopt($ch, CURLOPT_POST, 1);
@@ -461,7 +461,7 @@ if ($errorRate > 0) alert();  // Too sensitive
 
 ```php
 // ✅ Good - rich context
-logger()->error('Payment failed', [
+app($context, \Psr\Log\LoggerInterface::class)->error('Payment failed', [
     'order_id' => $order->id,
     'user_id' => $user->id,
     'amount' => $amount,
@@ -470,7 +470,7 @@ logger()->error('Payment failed', [
 ]);
 
 // ❌ Bad - minimal context
-logger()->error('Payment failed');
+app($context, \Psr\Log\LoggerInterface::class)->error('Payment failed');
 ```
 
 ### 4. Use Sampling for High Volume

--- a/content/5.deployment/security-hardening.md
+++ b/content/5.deployment/security-hardening.md
@@ -33,11 +33,11 @@ APP_DEBUG=false
 
 # Strong secrets (32+ chars, random)
 TOKEN_SALT=your-strong-random-salt
-# Framework reads config('session.jwt_key'); map from either env below as per your config loader
+# Framework reads config($context, 'session.jwt_key'); map from either env below as per your config loader
 SESSION_JWT_KEY=your-strong-jwt-signing-key
 JWT_ALGORITHM=HS256
 
-# Token lifetimes (framework consumes config('session.*_token_lifetime'))
+# Token lifetimes (framework consumes config($context, 'session.*_token_lifetime'))
 ACCESS_TOKEN_LIFETIME=3600        # 1 hour
 REFRESH_TOKEN_LIFETIME=604800     # 7 days
 
@@ -167,13 +167,13 @@ $password = sha1($password); // DON'T DO THIS
 
 ```php
 // Use TOKEN_SALT and JWT_KEY from session config
-config('session.token_salt');
-config('session.jwt_key');
-config('session.jwt_algorithm');
+config($context, 'session.token_salt');
+config($context, 'session.jwt_key');
+config($context, 'session.jwt_algorithm');
 
 // Token lifetimes via env
-config('session.access_token_lifetime');    // ACCESS_TOKEN_LIFETIME
-config('session.refresh_token_lifetime');   // REFRESH_TOKEN_LIFETIME
+config($context, 'session.access_token_lifetime');    // ACCESS_TOKEN_LIFETIME
+config($context, 'session.refresh_token_lifetime');   // REFRESH_TOKEN_LIFETIME
 ```
 
 ### Rate Limiting
@@ -197,16 +197,28 @@ class TaskController
     public function store(Request $request)
     {
         // ✅ Good - validate everything
-        $validated = $request->validate([
-            'title' => 'required|string|min:3|max:255',
-            'description' => 'nullable|string|max:1000',
-            'status' => 'nullable|in:pending,in_progress,completed',
-            'due_date' => 'nullable|date|after:today',
-        ]);
+        $data = $this->getRequestData();
 
-        $task = db()->table('tasks')->create($validated);
+        if ($error = $this->validateRequest($data, [
+            'title' => 'required|max:255',
+            'description' => 'max:1000',
+            'status' => 'max:32',
+            'due_date' => 'max:255',
+        ])) {
+            return $error;
+        }
 
-        return Response::success($task, 201);
+        $task = [
+            'uuid' => \Glueful\Helpers\Utils::generateNanoID(),
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'status' => $data['status'] ?? 'pending',
+            'due_date' => $data['due_date'] ?? null,
+        ];
+
+        db($context)->table('tasks')->insert($task);
+
+        return Response::created($task);
     }
 }
 ```
@@ -230,12 +242,12 @@ echo escape($user->name);
 
 ```php
 // ✅ Good - parameterized queries (default in Glueful)
-$users = db()->table('users')
+$users = db($context)->table('users')
     ->where('email', $email)
     ->get();
 
 // ❌ Bad - string concatenation
-$users = db()->raw("SELECT * FROM users WHERE email = '{$email}'");
+$users = db($context)->raw("SELECT * FROM users WHERE email = '{$email}'");
 ```
 
 ### Validate Input Types
@@ -319,10 +331,19 @@ php vendor/bin/glueful security:revoke-tokens --expired
 ### Validate File Uploads
 
 ```php
-$request->validate([
-    'avatar' => 'required|file|mimes:jpg,png|max:2048', // 2MB max
-    'document' => 'required|file|mimes:pdf|max:10240', // 10MB max
+$data = RequestHelper::getRequestData($request);
+
+$rules = (new RuleParser())->parse([
+    'avatar' => 'required|max:255',
+    'document' => 'required|max:255',
 ]);
+
+$validator = new Validator($rules);
+$errors = $validator->validate($data);
+
+if ($errors !== []) {
+    throw new ValidationException($errors);
+}
 ```
 
 ### Secure File Storage
@@ -344,7 +365,7 @@ class FileUploadController
         $filename = bin2hex(random_bytes(16)) . '.' . $file->getClientOriginalExtension();
 
         // Store outside public directory
-        $path = storage_path('uploads/avatars/' . $filename);
+        $path = storage_path($context, 'uploads/avatars/' . $filename);
         $file->move(dirname($path), $filename);
 
         return Response::success(['filename' => $filename]);
@@ -526,20 +547,20 @@ class Encryptor
 
 ```php
 // Failed login attempts
-logger()->warning('Failed login attempt', [
+app($context, \Psr\Log\LoggerInterface::class)->warning('Failed login attempt', [
     'email' => $email,
     'ip' => $request->ip(),
     'user_agent' => $request->userAgent(),
 ]);
 
 // Suspicious activity
-logger()->critical('Potential SQL injection attempt', [
+app($context, \Psr\Log\LoggerInterface::class)->critical('Potential SQL injection attempt', [
     'input' => $input,
     'ip' => $request->ip(),
 ]);
 
 // Access to admin endpoints
-logger()->info('Admin access', [
+app($context, \Psr\Log\LoggerInterface::class)->info('Admin access', [
     'user_id' => $user->id,
     'action' => $action,
     'ip' => $request->ip(),
@@ -560,7 +581,7 @@ class LoginAttemptTracker
         Cache::set($key, $attempts, 3600); // 1 hour
 
         if ($attempts >= 5) {
-            logger()->critical('Multiple failed login attempts', [
+            app($context, \Psr\Log\LoggerInterface::class)->critical('Multiple failed login attempts', [
                 'email' => $email,
                 'ip' => $ip,
                 'attempts' => $attempts,

--- a/content/5.deployment/zero-downtime.md
+++ b/content/5.deployment/zero-downtime.md
@@ -229,8 +229,8 @@ $schema->table('users', function ($table) {
 
 **Phase 2: Backfill data**
 ```php
-db()->table('users')->update([
-    'email_new' => db()->raw('email')
+db($context)->table('users')->update([
+    'email_new' => db($context)->raw('email')
 ]);
 ```
 
@@ -507,7 +507,7 @@ ssh server "git pull && composer install"
 
 // Include in responses
 return Response::success($data, headers: [
-    'X-App-Version' => config('app.version')
+    'X-App-Version' => config($context, 'app.version')
 ]);
 ```
 

--- a/content/6.cookbook/1.routing.md
+++ b/content/6.cookbook/1.routing.md
@@ -38,7 +38,7 @@ Routes are defined in the `routes/` directory and loaded automatically by the fr
 
 Note on context:
 - In route files (e.g., `routes/api.php`), the router instance `$router` is in scope (provided by the framework’s manifest loader), so you can call `$router->get(...)` directly.
-- In other contexts (e.g., bootstrapping/tests), resolve it from the container: `$router = container()->get(Glueful\\Routing\\Router::class);`
+- In other contexts (e.g., bootstrapping/tests), resolve it from the container: `$router = container($context)->get(Glueful\\Routing\\Router::class);`
 
 ```php
 use Glueful\Routing\Router;
@@ -616,7 +616,7 @@ class RouteTest extends TestCase
 - In development, route cache auto‑expires (5s). To force clear: delete `storage/cache/routes_dev.php` or call:
 
 ```php
-app(Glueful\Routing\RouteCache::class)->clear();
+app($context, Glueful\Routing\RouteCache::class)->clear();
 ```
 
 **Method not allowed (405)**
@@ -650,13 +650,13 @@ The Glueful Framework includes several built-in endpoint groups that demonstrate
 $router->group(['prefix' => '/health'], function (Router $router) {
     // Main health check - high rate limit for monitoring tools
     $router->get('/', function (Request $request) {
-        $healthController = container()->get(HealthController::class);
+        $healthController = container($context)->get(HealthController::class);
         return $healthController->index();
     })->middleware('rate_limit:60,60'); // 60 requests per minute
     
     // Specific component checks with lower limits
     $router->get('/database', function (Request $request) {
-        $healthController = container()->get(HealthController::class);
+        $healthController = container($context)->get(HealthController::class);
         return $healthController->database();
     })->middleware('rate_limit:30,60'); // 30 requests per minute
     
@@ -675,7 +675,7 @@ $router->group(['prefix' => '/health'], function (Router $router) {
 $router->group(['prefix' => '/auth'], function (Router $router) {
     // Login with strict rate limiting
     $router->post('/login', function (Request $request) {
-        $authController = container()->get(AuthController::class);
+        $authController = container($context)->get(AuthController::class);
         return $authController->login();
     })->middleware('rate_limit:5,60'); // 5 attempts per minute
     
@@ -701,7 +701,7 @@ $router->group(['prefix' => '/auth'], function (Router $router) {
 // RESTful resource endpoints with authentication
 // List resources with pagination
 $router->get('/{resource}', function (Request $request) {
-    $resourceController = container()->get(ResourceController::class);
+    $resourceController = container($context)->get(ResourceController::class);
     $pathInfo = $request->getPathInfo();
     $segments = explode('/', trim($pathInfo, '/'));
     $params = ['resource' => $segments[0]];
@@ -711,7 +711,7 @@ $router->get('/{resource}', function (Request $request) {
 
 // Get single resource by UUID
 $router->get('/{resource}/{uuid}', function (Request $request) {
-    $resourceController = container()->get(ResourceController::class);
+    $resourceController = container($context)->get(ResourceController::class);
     $pathInfo = $request->getPathInfo();
     $segments = explode('/', trim($pathInfo, '/'));
     $params = ['resource' => $segments[0], 'uuid' => $segments[1]];
@@ -721,7 +721,7 @@ $router->get('/{resource}/{uuid}', function (Request $request) {
 
 // Create resource
 $router->post('/{resource}', function (Request $request) {
-    $resourceController = container()->get(ResourceController::class);
+    $resourceController = container($context)->get(ResourceController::class);
     // Implementation...
 })->middleware(['auth', 'rate_limit:20,60']); // 20 creates per minute
 

--- a/content/6.cookbook/10.caching.md
+++ b/content/6.cookbook/10.caching.md
@@ -260,7 +260,7 @@ $fileCache = CacheFactory::create('file');
 $arrayCache = CacheFactory::create('array');
 
 // Optional fallback to file cache when configured
-// Set config('cache.fallback_to_file', true) to enable factory fallback
+// Set config($context, 'cache.fallback_to_file') to true to enable factory fallback
 $cache = CacheFactory::create();
 
 // For graceful fallback on connection errors, prefer
@@ -612,7 +612,7 @@ $edgeCache->purgeByTag('users');
 $edgeCache->purgeAll();
 
 // CDN provider configuration is resolved via extensions and
-// config('cache.edge.provider'), not by calling setProvider() directly.
+// config($context, 'cache.edge.provider'), not by calling setProvider() directly.
 ```
 
 ## CLI Commands
@@ -705,7 +705,7 @@ return [
         
         'file' => [
             'driver' => 'file',
-            'path' => env('CACHE_FILE_PATH', storage_path('cache')),
+            'path' => env('CACHE_FILE_PATH', storage_path($context, 'cache')),
             'hash_levels' => 2, // Directory structure depth
             'cleanup_frequency' => 3600 // Cleanup every hour
         ]

--- a/content/6.cookbook/11.queues-and-jobs.md
+++ b/content/6.cookbook/11.queues-and-jobs.md
@@ -347,14 +347,14 @@ class CacheMaintenanceJob extends Job
             $result = $task->handle($options);
 
             // Log successful completion
-            app(LogManager::class)->info('Cache maintenance completed successfully', [
+            app($context, LogManager::class)->info('Cache maintenance completed successfully', [
                 'operation' => $operation,
                 'result' => $result,
                 'job_uuid' => $this->getUuid()
             ]);
 
         } catch (\Exception $e) {
-            app(LogManager::class)->error('Cache maintenance failed', [
+            app($context, LogManager::class)->error('Cache maintenance failed', [
                 'operation' => $operation,
                 'error' => $e->getMessage(),
                 'job_uuid' => $this->getUuid()
@@ -369,7 +369,7 @@ class CacheMaintenanceJob extends Job
         $operation = $data['operation'] ?? 'clearExpiredKeys';
         $options = $data['options'] ?? [];
 
-        app(LogManager::class)->error('Cache maintenance job failed', [
+        app($context, LogManager::class)->error('Cache maintenance job failed', [
             'operation' => $operation,
             'options' => $options,
             'error' => $exception->getMessage()
@@ -386,7 +386,7 @@ $task = new CacheMaintenanceTask();
 $result = $task->handle(['operation' => 'clearExpiredKeys', 'verbose' => true]);
 
 // Queued execution
-$queueManager = app(QueueManager::class);
+$queueManager = app($context, QueueManager::class);
 $jobId = $queueManager->push(CacheMaintenanceJob::class, [
     'operation' => 'clearExpiredKeys',
     'options' => ['verbose' => true]
@@ -445,7 +445,7 @@ class ProcessEmailJob extends Job
         $data = $this->getData();
         
         // Send email
-        $emailService = container()->get(EmailService::class);
+        $emailService = container($context)->get(EmailService::class);
         $emailService->send(
             $data['to'],
             $data['subject'],
@@ -454,7 +454,7 @@ class ProcessEmailJob extends Job
         );
         
         // Log success
-        logger()->info('Email sent successfully', [
+        app($context, \Psr\Log\LoggerInterface::class)->info('Email sent successfully', [
             'job_uuid' => $this->getUuid(),
             'recipient' => $data['to'],
             'template' => $data['template']
@@ -469,7 +469,7 @@ class ProcessEmailJob extends Job
         $data = $this->getData();
         
         // Log failure
-        logger()->error('Email job failed', [
+        app($context, \Psr\Log\LoggerInterface::class)->error('Email job failed', [
             'job_uuid' => $this->getUuid(),
             'recipient' => $data['to'],
             'error' => $exception->getMessage(),
@@ -478,7 +478,7 @@ class ProcessEmailJob extends Job
         
         // Notify admin for critical emails
         if ($data['critical'] ?? false) {
-            $notificationService = container()->get(NotificationService::class);
+            $notificationService = container($context)->get(NotificationService::class);
             $notificationService->alertAdmin('Critical email job failed', [
                 'job_uuid' => $this->getUuid(),
                 'error' => $exception->getMessage()
@@ -516,13 +516,13 @@ class ProcessImagesJob extends Job
                 $this->processImage($imageId);
             } catch (\Exception $e) {
                 // Log individual image failure but continue processing
-                logger()->warning('Image processing failed', [
+                app($context, \Psr\Log\LoggerInterface::class)->warning('Image processing failed', [
                     'image_id' => $imageId,
                     'error' => $e->getMessage()
                 ]);
                 
                 // Create separate retry job for failed image
-                $queueManager = container()->get(QueueManager::class);
+                $queueManager = container($context)->get(QueueManager::class);
                 $queueManager->later(300, ProcessSingleImageJob::class, [
                     'image_id' => $imageId,
                     'retry_count' => ($data['retry_count'] ?? 0) + 1
@@ -818,7 +818,7 @@ class BatchProgressTracker
     public function getBatchProgress(string $batchUuid): array
     {
         // Get batch job statistics from database
-        $db = container()->get(DatabaseInterface::class);
+        $db = container($context)->get(DatabaseInterface::class);
         
         $completed = $db->count('queue_jobs_completed', ['batch_uuid' => $batchUuid]);
         $failed = $db->count('queue_failed_jobs', ['batch_uuid' => $batchUuid]);
@@ -862,7 +862,7 @@ class NewsletterBatchJob extends Job
             return true; // Not part of batch
         }
         
-        $db = container()->get(DatabaseInterface::class);
+        $db = container($context)->get(DatabaseInterface::class);
         $remaining = $db->count('queue_jobs', ['batch_uuid' => $batchUuid]);
         
         return $remaining <= 1; // This job is the last one
@@ -873,7 +873,7 @@ class NewsletterBatchJob extends Job
         $batchUuid = $this->getBatchUuid();
         
         // Create completion job
-        $queueManager = container()->get(QueueManager::class);
+        $queueManager = container($context)->get(QueueManager::class);
         $queueManager->push(NewsletterBatchCompletedJob::class, [
             'batch_uuid' => $batchUuid,
             'completed_at' => date('Y-m-d H:i:s')
@@ -893,7 +893,7 @@ class NewsletterBatchCompletedJob extends Job
         $progress = $tracker->getBatchProgress($batchUuid);
         
         // Send completion notification
-        $notificationService = container()->get(NotificationService::class);
+        $notificationService = container($context)->get(NotificationService::class);
         $notificationService->send(
             'admin@example.com',
             'Newsletter Batch Completed',

--- a/content/6.cookbook/12.events.md
+++ b/content/6.cookbook/12.events.md
@@ -1,1390 +1,183 @@
 ---
-title:  Events
-description: 
+title: Events
+description: Practical patterns for dispatching and handling events in Glueful
 ---
 
+This page focuses on event patterns that match the current framework surface.
 
-## Overview
+For standalone snippets below, assume `$context` is an available `ApplicationContext`. In controllers, prefer `$this->getContext()` and your injected services.
 
-The Glueful framework provides a comprehensive event system built on PSR-14 (Event Dispatcher), enabling decoupled communication between framework components and application code. The system clearly separates framework infrastructure concerns from application business logic through well-defined event boundaries.
+## When To Use Events
 
-## Table of Contents
+Use events when:
 
-- [Architecture](#architecture)
-- [Framework vs Application Boundaries](#framework-vs-application-boundaries)
-- [Core Event Categories](#core-event-categories)
-- [Authentication Events](#authentication-events)
-- [Security Events](#security-events)
-- [Session Analytics Events](#session-analytics-events)
-- [HTTP Events](#http-events)
-- [Database Events](#database-events)
-- [Cache Events](#cache-events)
-- [Logging System Integration](#logging-system-integration)
-- [Event Listeners](#event-listeners)
-- [Creating Custom Events](#creating-custom-events)
-- [Extension Integration](#extension-integration)
-- [Performance Monitoring](#performance-monitoring)
-- [Best Practices](#best-practices)
-- [Command Reference](#command-reference)
+- multiple parts of the system react to the same action
+- side effects should stay decoupled from the main request
+- some reactions can be queued or retried independently
 
-## Architecture
+Use direct service calls when:
 
-### Event Flow
+- there is only one consumer
+- the action must complete synchronously
+- introducing fan-out would make the flow harder to reason about
 
-```
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-│  Framework      │───▶│  Event System    │───▶│  Application    │
-│  Components     │    │  (Dispatcher)    │    │  Listeners      │
-└─────────────────┘    └──────────────────┘    └─────────────────┘
-                              │
-                              ▼
-                       ┌─────────────────┐
-                       │  Extensions     │
-                       │  Listeners      │
-                       └─────────────────┘
-```
-
-### Key Features
-
-- **Type-safe events** with PHP 8.3+ readonly properties
-- **Framework boundary separation** for clear responsibility division
-- **Performance monitoring** built into event system
-- **Extension integration** with priority-based listeners
-- **Logging system integration** with structured context
-- **Session analytics** for user behavior tracking
-- **Security event monitoring** for threat detection
-
-## Event System Abstraction Layer
-
-Glueful provides a complete abstraction layer over the underlying event system (PSR-14 EventDispatcher) to ensure framework consistency and future-proofing.
-
-### BaseEvent Class
-
-All Glueful events extend the `BaseEvent` class which implements PSR-14's `StoppableEventInterface`:
+## Dispatch An Event
 
 ```php
-<?php
-
-namespace Glueful\Events\Contracts;
-
-use Psr\EventDispatcher\StoppableEventInterface;
-
-abstract class BaseEvent implements StoppableEventInterface
-{
-    private bool $stopped = false;
-    /** @var array<string, mixed> */
-    private array $metadata = [];
-    private float $timestamp;
-    private string $eventId;
-
-    public function __construct()
-    {
-        $this->timestamp = microtime(true);
-        $this->eventId = uniqid('evt_', true);
-    }
-
-    // PSR-14 propagation
-    public function stopPropagation(): void { $this->stopped = true; }
-    public function isPropagationStopped(): bool { return $this->stopped; }
-
-    // Framework helpers
-    public function setMetadata(string $key, mixed $value): void { $this->metadata[$key] = $value; }
-    public function getMetadata(?string $key = null): mixed { return $key === null ? $this->metadata : ($this->metadata[$key] ?? null); }
-    public function getTimestamp(): float { return $this->timestamp; }
-    public function getEventId(): string { return $this->eventId; }
-    public function getName(): string { return static::class; }
-}
-```
-
-### Benefits of the Abstraction Layer
-
-1. **PSR-14 Compliance**: Full compatibility with PSR-14 EventDispatcher standard
-2. **Framework Features**: All events automatically get event IDs, timestamps, and metadata support
-3. **Event Propagation Control**: Built-in support for stopping event propagation
-4. **Future-Proof**: Can change underlying implementation without breaking user code
-5. **Consistency**: Aligns with Glueful's philosophy of hiding implementation details
-6. **Extensibility**: Easy to add new framework-wide features to all events
-
-### Creating Custom Events
-
-When creating custom events, always extend BaseEvent:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Events;
-
-use Glueful\Events\Contracts\BaseEvent;
-
-class OrderShippedEvent extends BaseEvent
-{
-    public function __construct(
-        public readonly string $orderId,
-        public readonly string $trackingNumber
-    ) {
-        parent::__construct(); // Initialize BaseEvent features
-        
-        // Set metadata using BaseEvent's functionality
-        $this->setMetadata('source', 'order_service');
-        $this->setMetadata('priority', 'high');
-    }
-}
-```
-
-### Enhanced Event Dispatching
-
-Events are dispatched using the PSR-14 compliant Event facade:
-
-```php
+use App\Events\UserRegisteredEvent;
 use Glueful\Events\Event;
 
-$event = new OrderShippedEvent('123', 'TRACK456');
-Event::dispatch($event);
-
-// Framework automatically tracks:
-// - Event ID: evt_64f1a2b3c4d5e
-// - Event Name: App\Events\OrderShippedEvent
-// - Timestamp: 1693234567.123
-// - Any custom metadata
-// - Propagation control (if event is stopped)
-```
-
-### Event Facade API
-
-The Event facade provides these methods:
-
-```php
-use Glueful\Events\Event;
-
-// Dispatch an event
-$result = Event::dispatch($event);
-
-// Register listeners with optional priority
-Event::listen(UserLoginEvent::class, $callable, $priority = 0);
-Event::listen(UserLoginEvent::class, '@service:method', 10);
-
-// Register subscriber classes
-Event::subscribe(UserEventSubscriber::class);
-
-// Check for listeners
-$hasListeners = Event::hasListeners(UserLoginEvent::class);
-$listeners = Event::getListeners(UserLoginEvent::class);
-```
-
-## Framework vs Application Boundaries
-
-### Framework Responsibilities
-
-The framework emits events for **infrastructure and protocol concerns**:
-
-- HTTP protocol validation (auth headers, CSRF tokens)
-- Rate limiting enforcement
-- Database query execution
-- Cache operations
-- Session lifecycle management
-- Security policy violations
-
-### Application Responsibilities
-
-Applications listen to framework events and implement **business logic responses**:
-
-- User behavior analytics
-- Business rule enforcement
-- Custom security policies
-- Audit trail creation
-- Notification dispatch
-- Integration with external services
-
-### Boundary Example
-
-```php
-// Framework: Detects rate limit violation (infrastructure concern)
-use Glueful\Events\Auth\RateLimitExceededEvent;
-use Glueful\Events\Event;
-
-Event::dispatch(new RateLimitExceededEvent(
-    clientIp: $ip,
-    rule: 'default_limit',
-    currentCount: $count,
-    limit: $limit,
-    windowSeconds: $window,
+Event::dispatch(new UserRegisteredEvent(
+    userId: $user['uuid'],
+    email: $user['email'],
 ));
-
-// Application: Responds with business logic
-Event::listen(RateLimitExceededEvent::class, function(RateLimitExceededEvent $event) {
-    if ($event->isSevereViolation()) {
-        $this->security->temporaryBlockIp($event->getClientIp());
-        $this->alerts->critical('Severe rate limit violation', ['ip' => $event->getClientIp()]);
-    }
-});
 ```
 
-## Core Event Categories
+## Register A Listener
 
-### 1. Authentication Events (`Glueful\Events\Auth`)
-- User session lifecycle
-- Authentication attempts and failures
-- Rate limit violations (Auth)
-
-### 2. Security Events (`Glueful\Events\Security`)
-- CSRF protection failures
-- Administrative/security violations
-
-### 3. HTTP Events (`Glueful\Events\Http`)
-- Request/response lifecycle
-- HTTP authentication
-- Exception handling
-- Client interaction tracking
-
-### 4. Database Events (`Glueful\Events\Database`)
-- Query execution monitoring
-- Entity lifecycle management
-- Performance tracking
-- Data modification auditing
-
-### 5. Cache Events (`Glueful\Events\Cache`)
-- Cache operations (hit/miss/invalidation)
-- Performance monitoring
-- Cache strategy optimization
-
-<!-- Note: `Glueful\Events\Analytics` is not implemented in core at this time. -->
-
-## Authentication Events
-
-Note: The following events exist in core. A `UserAuthenticatedEvent` is not currently provided by the framework.
-
-### AuthenticationFailedEvent (`Glueful\Events\Auth\AuthenticationFailedEvent`)
-
-**When**: Authentication attempt fails
-**Purpose**: Security monitoring and user experience improvement
-
-- Namespace: `Glueful\Events\Auth\AuthenticationFailedEvent`
-- Access: `getUsername()`, `getReason()`, `getClientIp()`, `getUserAgent()`, `isInvalidCredentials()`, `isUserDisabled()`, `isSuspicious()`
-
-### SessionCreatedEvent (`Glueful\Events\Auth\SessionCreatedEvent`)
-
-**When**: New user session is established
-**Purpose**: Session analytics and initialization
-
-- Namespace: `Glueful\Events\Auth\SessionCreatedEvent`
-- Access: `getSessionData()`, `getUserUuid()`, `getUsername()`, `getTokens()`, `getAccessToken()`, `getRefreshToken()`
-
-### SessionDestroyedEvent (`Glueful\Events\Auth\SessionDestroyedEvent`)
-
-**When**: User session is terminated
-**Purpose**: Cleanup and analytics
-
-- Namespace: `Glueful\Events\Auth\SessionDestroyedEvent`
-- Access: `getAccessToken()`, `getUserUuid()`, `getReason()`, `isExpired()`, `isRevoked()`
-
-## Security & Rate Limiting
-
-### RateLimitExceededEvent (`Glueful\Events\Auth\RateLimitExceededEvent`)
-
-**When**: Rate limit is exceeded
-**Purpose**: Security monitoring and adaptive responses
-
-- Namespace: `Glueful\Events\Auth\RateLimitExceededEvent`
-- Access: `getClientIp()`, `getRule()`, `getCurrentCount()`, `getLimit()`, `getWindowSeconds()`, `getExcessCount()`, `getExcessPercentage()`, `isSevereViolation()`
-
-**Usage Example**:
 ```php
+use App\Events\UserRegisteredEvent;
+use App\Jobs\SendWelcomeEmailJob;
 use Glueful\Events\Event;
+use Glueful\Queue\QueueManager;
 
-Event::listen(RateLimitExceededEvent::class, function(RateLimitExceededEvent $event) {
-    if ($event->isSevereViolation()) {
-        $this->securityManager->blockIP($event->getClientIp(), '1 hour');
-    } else {
-        $this->rateLimiter->penaltyMode($event->getClientIp(), '10 minutes');
-    }
-});
-```
-
-### CSRFViolationEvent (`Glueful\Events\Security\CSRFViolationEvent`)
-
-**When**: CSRF token validation fails
-**Purpose**: Security monitoring and attack prevention
-
-- Namespace: `Glueful\Events\Security\CSRFViolationEvent`
-- Access: `reason`, `request` (Symfony Request)
-
-<!-- SuspiciousActivityDetectedEvent is not present in core. Omitted. -->
-
-## Session Analytics Events
-
-### SessionActivityEvent
-
-**When**: User performs actions during session
-**Purpose**: User behavior analytics and experience optimization
-
-```php
-namespace Glueful\Events\Analytics;
-
-use Glueful\Events\Contracts\BaseEvent;
-
-class SessionActivityEvent extends BaseEvent
-{
-    public function __construct(
-        public readonly string $sessionId,
-        public readonly string $userId,
-        public readonly string $action,
-        public readonly string $resource,
-        public readonly array $parameters = [],
-        public readonly float $responseTime = 0.0,
-        public readonly array $metadata = []
-    ) {}
-    
-    public function isSlowResponse(): bool
-    {
-        return $this->responseTime > 2.0;
-    }
-    
-    public function isErrorResponse(): bool
-    {
-        return isset($this->metadata['status_code']) && 
-               $this->metadata['status_code'] >= 400;
-    }
-}
-```
-
-**Usage Example**:
-```php
-use Glueful\Events\Event;
-
-Event::listen(SessionActivityEvent::class, function(SessionActivityEvent $event) {
-    // User behavior analytics
-    $this->analyticsService->recordUserAction([
-        'user_id' => $event->userId,
-        'action' => $event->action,
-        'resource' => $event->resource,
-        'response_time' => $event->responseTime,
-        'timestamp' => now()->toISOString()
+Event::listen(UserRegisteredEvent::class, function (UserRegisteredEvent $event) use ($context): void {
+    $queue = app($context, QueueManager::class);
+    $queue->push(SendWelcomeEmailJob::class, [
+        'userId' => $event->userId,
+        'email' => $event->email,
     ]);
-    
-    // Performance monitoring
-    if ($event->isSlowResponse()) {
-        $this->performanceMonitor->recordSlowAction($event);
-    }
-    
-    // User experience optimization
-    if ($event->isErrorResponse()) {
-        $this->uxAnalyzer->recordErrorPattern($event);
-    }
 });
 ```
 
-### SessionPatternEvent
-
-**When**: Session usage patterns are analyzed
-**Purpose**: Advanced analytics and personalization
-
-```php
-namespace Glueful\Events\Analytics;
-
-use Glueful\Events\Contracts\BaseEvent;
-
-class SessionPatternEvent extends BaseEvent
-{
-    public function __construct(
-        public readonly string $userId,
-        public readonly string $patternType, // usage, navigation, preference
-        public readonly array $pattern,
-        public readonly float $confidence,
-        public readonly array $recommendations = []
-    ) {}
-    
-    public function isHighConfidence(): bool
-    {
-        return $this->confidence >= 0.85;
-    }
-}
-```
-
-## HTTP Events
-
-### RequestReceivedEvent
-
-**When**: HTTP request is received and parsed
-**Purpose**: Request tracking and analysis
-
-```php
-namespace Glueful\Events\Http;
-
-use Glueful\Events\Contracts\BaseEvent;
-
-class RequestReceivedEvent extends BaseEvent
-{
-    public function __construct(
-        public readonly Request $request,
-        public readonly float $timestamp,
-        public readonly array $metadata = []
-    ) {}
-    
-    public function isAPIRequest(): bool
-    {
-        return str_starts_with($this->request->getPathInfo(), '/api/');
-    }
-    
-    public function isSecure(): bool
-    {
-        return $this->request->isSecure();
-    }
-    
-    public function getEndpoint(): string
-    {
-        return $this->request->getMethod() . ' ' . $this->request->getPathInfo();
-    }
-}
-```
-
-### ResponseSentEvent
-
-**When**: HTTP response is sent to client
-**Purpose**: Performance monitoring and analytics
-
-```php
-namespace Glueful\Events\Http;
-
-use Glueful\Events\Contracts\BaseEvent;
-
-class ResponseSentEvent extends BaseEvent
-{
-    public function __construct(
-        public readonly Request $request,
-        public readonly Response $response,
-        public readonly float $processingTime,
-        public readonly array $metrics = []
-    ) {}
-    
-    public function isError(): bool
-    {
-        return $this->response->getStatusCode() >= 400;
-    }
-    
-    public function isSlowResponse(): bool
-    {
-        return $this->processingTime > 1.0;
-    }
-    
-    public function getStatusCode(): int
-    {
-        return $this->response->getStatusCode();
-    }
-}
-```
-
-## Database Events
-
-### QueryExecutedEvent
-
-**When**: Database query is executed
-**Purpose**: Performance monitoring and audit
-
-- Namespace: `Glueful\Events\Database\QueryExecutedEvent`
-- Access: `getSql()`, `getBindings()`, `getExecutionTime()`, `getConnectionName()`, `isSlow()`, `getQueryType()`, `isModifying()`
-
-**Usage Example**:
-```php
-use Glueful\Events\Event;
-
-Event::listen(QueryExecutedEvent::class, function(QueryExecutedEvent $event) {
-    // Performance monitoring
-    if ($event->isSlow()) {
-        $this->performanceLogger->warning('Slow query detected', [
-            'query' => $event->getSql(),
-            'execution_time' => $event->getExecutionTime(),
-            'type' => $event->getQueryType(),
-            'connection' => $event->getConnectionName(),
-        ]);
-    }
-    
-    // Audit trail for data modifications
-    if ($event->isModifying()) {
-        $this->auditService->logDataChange([
-            'operation' => $event->getQueryType(),
-            'query' => $event->getSql(),
-            'connection' => $event->getConnectionName(),
-            'timestamp' => now()->toISOString()
-        ]);
-    }
-    
-    // Query analytics
-    $this->queryAnalytics->recordQuery($event);
-});
-```
-
-### EntityCreatedEvent and EntityUpdatedEvent
-
-Core exposes separate events for lifecycle changes:
-
-- EntityCreatedEvent (`Glueful\Events\Database\EntityCreatedEvent`)
-  - Access: `getEntity()`, `getTable()`
-- EntityUpdatedEvent (`Glueful\Events\Database\EntityUpdatedEvent`)
-  - Access: `getEntity()`, `getTable()`, `getChanges()`
-
-## Cache Events
-
-Cache operations are modeled as distinct events in core (use these in listeners/examples):
-
-- `Glueful\Events\Cache\CacheHitEvent`
-- `Glueful\Events\Cache\CacheMissEvent`
-- `Glueful\Events\Cache\CacheInvalidatedEvent`
-
-**Usage Example**:
-```php
-use Glueful\Events\Event;
-
-use Glueful\Events\Cache\CacheHitEvent;
-use Glueful\Events\Cache\CacheMissEvent;
-
-Event::listen(CacheHitEvent::class, function(CacheHitEvent $event) {
-    if ($event->isSlow(0.1)) {
-        $this->logger->warning('Slow cache retrieval', [
-            'key' => $event->getKey(),
-            'time' => $event->getRetrievalTime(),
-            'size' => $event->getValueSize(),
-        ]);
-    }
-});
-
-Event::listen(CacheMissEvent::class, function(CacheMissEvent $event) {
-    $this->analytics->recordCacheMiss($event->getKey());
-});
-```
-
-## Logging System Integration
-
-### Structured Event Logging
-
-The framework provides seamless integration with the logging system through event-driven structured logging:
-
-```php
-namespace Glueful\Logging;
-
-class EventLoggerListener
-{
-    public function __construct(
-        private LoggerInterface $logger,
-        private ContextEnricher $contextEnricher
-    ) {}
-    
-    public function logAuthenticationEvent(UserAuthenticatedEvent $event): void
-    {
-        $context = $this->contextEnricher->enrich([
-            'event_type' => 'authentication',
-            'user_id' => $event->userId,
-            'auth_method' => $event->authMethod,
-            'client_ip' => $event->clientIp,
-            'user_agent' => $event->userAgent,
-            'session_data' => $event->sessionData
-        ]);
-        
-        $this->logger->info('User authenticated successfully', $context);
-    }
-    
-    public function logSecurityEvent(RateLimitExceededEvent $event): void
-    {
-        $context = $this->contextEnricher->enrich([
-            'event_type' => 'security_violation',
-            'violation_type' => 'rate_limit_exceeded',
-            'client_ip' => $event->clientIp,
-            'endpoint' => $event->endpoint,
-            'current_count' => $event->currentCount,
-            'limit_config' => $event->limitConfig,
-            'severity' => $event->isSeverViolation() ? 'high' : 'medium'
-        ]);
-        
-        $this->logger->warning('Rate limit exceeded', $context);
-    }
-    
-    public function logPerformanceEvent(QueryExecutedEvent $event): void
-    {
-        if ($event->isSlow()) {
-            $context = $this->contextEnricher->enrich([
-                'event_type' => 'performance',
-                'component' => 'database',
-                'query_type' => $event->getQueryType(),
-                'execution_time' => $event->executionTime,
-                'affected_table' => $event->getAffectedTable(),
-                'query_hash' => hash('sha256', $event->sql)
-            ]);
-            
-            $this->logger->warning('Slow database query detected', $context);
-        }
-    }
-}
-```
-
-### Context Enrichment
-
-```php
-namespace Glueful\Logging;
-
-class ContextEnricher
-{
-    public function enrich(array $context): array
-    {
-        return array_merge($context, [
-            'timestamp' => now()->toISOString(),
-            'request_id' => $this->getRequestId(),
-            'trace_id' => $this->getTraceId(),
-            'user_session' => $this->getCurrentSession(),
-            'environment' => config('app.env'),
-            'version' => config('app.version')
-        ]);
-    }
-    
-    private function getRequestId(): ?string
-    {
-        return request()?->headers->get('X-Request-ID');
-    }
-    
-    private function getTraceId(): ?string
-    {
-        return request()?->headers->get('X-Trace-ID');
-    }
-    
-    private function getCurrentSession(): ?array
-    {
-        $session = session();
-        return $session ? [
-            'id' => $session->getId(),
-            'user_id' => $session->get('user_id')
-        ] : null;
-    }
-}
-```
-
-## Event Listeners
-
-### Built-in Framework Listeners
-
-#### SecurityMonitoringListener
-
-```php
-namespace Glueful\Events\Listeners;
-
-class SecurityMonitoringListener
-{
-    public function __construct(
-        private SecurityAnalyzer $analyzer,
-        private ThreatDetector $threatDetector,
-        private AlertService $alertService
-    ) {}
-    
-    public function onAuthenticationFailed(AuthenticationFailedEvent $event): void
-    {
-        $this->analyzer->recordFailedAttempt($event);
-        
-        if ($this->threatDetector->isBruteForcePattern($event)) {
-            $this->alertService->securityAlert('brute_force_detected', $event);
-        }
-    }
-    
-    public function onRateLimitExceeded(RateLimitExceededEvent $event): void
-    {
-        $this->analyzer->recordRateLimitViolation($event);
-        
-        if ($event->isSeverViolation()) {
-            $this->alertService->criticalAlert('severe_rate_limit_violation', $event);
-        }
-    }
-    
-    public function onSuspiciousActivity(SuspiciousActivityDetectedEvent $event): void
-    {
-        if ($event->isHighRisk()) {
-            $this->alertService->securityAlert('high_risk_activity', $event);
-            $this->analyzer->initiateDetailedAnalysis($event);
-        }
-    }
-}
-```
-
-#### PerformanceMonitoringListener
-
-```php
-namespace Glueful\Events\Listeners;
-
-class PerformanceMonitoringListener
-{
-    public function __construct(
-        private MetricsCollector $metrics,
-        private PerformanceAnalyzer $analyzer,
-        private AlertService $alertService
-    ) {}
-    
-    public function onQueryExecuted(QueryExecutedEvent $event): void
-    {
-        $this->metrics->recordQueryMetrics([
-            'execution_time' => $event->executionTime,
-            'query_type' => $event->getQueryType(),
-            'table' => $event->getAffectedTable()
-        ]);
-        
-        if ($event->isSlow()) {
-            $this->analyzer->analyzeSlowQuery($event);
-        }
-    }
-    
-    public function onResponseSent(ResponseSentEvent $event): void
-    {
-        $this->metrics->recordResponseMetrics([
-            'processing_time' => $event->processingTime,
-            'status_code' => $event->getStatusCode(),
-            'endpoint' => $event->request->getPathInfo()
-        ]);
-        
-        if ($event->isSlowResponse()) {
-            $this->analyzer->analyzeSlowResponse($event);
-        }
-    }
-    
-    public function onCacheOperation(CacheOperationEvent $event): void
-    {
-        $this->metrics->recordCacheMetrics([
-            'operation' => $event->operation,
-            'hit' => $event->isHit(),
-            'operation_time' => $event->operationTime
-        ]);
-    }
-}
-```
-
-#### AnalyticsListener
-
-```php
-namespace Glueful\Events\Listeners;
-
-class AnalyticsListener
-{
-    public function __construct(
-        private AnalyticsService $analytics,
-        private UserBehaviorTracker $behaviorTracker
-    ) {}
-    
-    public function onUserAuthenticated(UserAuthenticatedEvent $event): void
-    {
-        $this->analytics->recordEvent('user_login', [
-            'user_id' => $event->userId,
-            'method' => $event->authMethod,
-            'timestamp' => now()->toISOString()
-        ]);
-    }
-    
-    public function onSessionActivity(SessionActivityEvent $event): void
-    {
-        $this->behaviorTracker->recordActivity([
-            'user_id' => $event->userId,
-            'action' => $event->action,
-            'resource' => $event->resource,
-            'response_time' => $event->responseTime
-        ]);
-    }
-    
-    public function onSessionDestroyed(SessionDestroyedEvent $event): void
-    {
-        $this->analytics->recordEvent('session_ended', [
-            'user_id' => $event->userId,
-            'duration' => $event->duration,
-            'reason' => $event->reason
-        ]);
-    }
-}
-```
-
-### Custom Application Listeners
-
-```php
-// In your application
-class MyApplicationEventListener
-{
-    public function __construct(
-        private BusinessAnalytics $analytics,
-        private NotificationService $notifications
-    ) {}
-    
-    public function onUserAuthenticated(UserAuthenticatedEvent $event): void
-    {
-        // Business-specific login tracking
-        $this->analytics->userLoggedIn($event->userId);
-        
-        // Send welcome notification for first-time users
-        if ($this->isFirstLogin($event->userId)) {
-            $this->notifications->sendWelcomeMessage($event->userId);
-        }
-    }
-    
-    public function onEntityCreated(EntityLifecycleEvent $event): void
-    {
-        // Business workflow triggers
-        if ($event->entityType === 'order' && $event->isCreated()) {
-            $this->processNewOrder($event->entityId, $event->entityData);
-        }
-    }
-    
-    private function isFirstLogin(string $userId): bool
-    {
-        return $this->analytics->getLoginCount($userId) === 1;
-    }
-    
-    private function processNewOrder(string $orderId, array $orderData): void
-    {
-        // Business logic for new orders
-        $this->notifications->notifyWarehouse($orderId);
-        $this->analytics->recordSale($orderData);
-    }
-}
-```
-
-## Creating Custom Events
-
-### Step 1: Define Event Class
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Events;
-
-use Glueful\Events\Contracts\BaseEvent;
-
-class OrderShippedEvent extends BaseEvent
-{
-    public function __construct(
-        public readonly string $orderId,
-        public readonly string $customerId,
-        public readonly string $trackingNumber,
-        public readonly string $carrier,
-        public readonly array $items,
-        public readonly array $shippingAddress,
-        public readonly float $shippingCost,
-        array $metadata = []
-    ) {
-        parent::__construct(); // Initialize BaseEvent features
-        
-        // Set metadata using BaseEvent's functionality
-        foreach ($metadata as $key => $value) {
-            $this->setMetadata($key, $value);
-        }
-    }
-    
-    public function getItemCount(): int
-    {
-        return count($this->items);
-    }
-    
-    public function isExpressShipping(): bool
-    {
-        return ($this->getMetadata('shipping_method') ?? '') === 'express';
-    }
-    
-    public function isInternational(): bool
-    {
-        return ($this->shippingAddress['country'] ?? 'US') !== 'US';
-    }
-}
-```
-
-### Step 2: Dispatch Event
-
-```php
-namespace App\Services;
-
-use Glueful\Events\Event;
-use App\Events\OrderShippedEvent;
-
-class OrderService
-{
-    public function shipOrder(string $orderId): void
-    {
-        $order = $this->getOrder($orderId);
-        
-        // Ship the order
-        $trackingNumber = $this->shippingProvider->ship($order);
-        
-        // Update order status
-        $this->updateOrderStatus($orderId, 'shipped');
-        
-        // Dispatch event
-        $event = new OrderShippedEvent(
-            orderId: $orderId,
-            customerId: $order['customer_id'],
-            trackingNumber: $trackingNumber,
-            carrier: $order['shipping_carrier'],
-            items: $order['items'],
-            shippingAddress: $order['shipping_address'],
-            shippingCost: $order['shipping_cost'],
-            metadata: [
-                'shipping_method' => $order['shipping_method'],
-                'shipped_at' => now()->toISOString()
-            ]
-        );
-        
-        Event::dispatch($event);
-    }
-}
-```
-
-### Step 3: Create Listeners
-
-```php
-// Service for handling shipping notifications
-class ShippingNotificationService
-{
-    public function onOrderShipped(OrderShippedEvent $event): void
-    {
-        // Send tracking email to customer
-        $this->emailService->sendTrackingEmail(
-            $event->customerId,
-            $event->orderId,
-            $event->trackingNumber,
-            $event->carrier
-        );
-        
-        // Send SMS for express shipping
-        if ($event->isExpressShipping()) {
-            $this->smsService->sendShippingAlert(
-                $event->customerId,
-                $event->trackingNumber
-            );
-        }
-    }
-}
-
-// Analytics service
-class ShippingAnalyticsService
-{
-    public function onOrderShipped(OrderShippedEvent $event): void
-    {
-        $this->analytics->recordShipping([
-            'order_id' => $event->orderId,
-            'carrier' => $event->carrier,
-            'item_count' => $event->getItemCount(),
-            'shipping_cost' => $event->shippingCost,
-            'is_express' => $event->isExpressShipping(),
-            'is_international' => $event->isInternational(),
-            'timestamp' => now()->toISOString()
-        ]);
-    }
-}
-```
-
-## Extension Integration
-
-### Registering Event Listeners in Extensions
-
-```php
-namespace Glueful\Extensions\MyExtension;
-
-use Glueful\Extensions\BaseExtension;
-use Glueful\Events\Event;
-use Glueful\Events\EventSubscriberInterface;
-
-class Extension extends BaseExtension
-{
-    public function boot(): void
-    {
-        // Register event subscriber
-        Event::subscribe(ExtensionEventSubscriber::class);
-
-        // Or register individual listeners
-        Event::listen(UserAuthenticatedEvent::class, '@extension_analytics:trackLogin', 10);
-        Event::listen(QueryExecutedEvent::class, [$this, 'onQueryExecuted'], 5);
-    }
-
-    public function onQueryExecuted(QueryExecutedEvent $event): void
-    {
-        // Extension-specific database monitoring
-        if ($event->isSlow()) {
-            $this->alertSlowQuery($event);
-        }
-    }
-}
-
-class ExtensionEventSubscriber implements EventSubscriberInterface
-{
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            UserAuthenticatedEvent::class => 'onUserAuthenticated',
-            RateLimitExceededEvent::class => ['onRateLimitExceeded', 100]
-        ];
-    }
-
-    public function onUserAuthenticated(UserAuthenticatedEvent $event): void
-    {
-        // Extension-specific logic
-    }
-
-    public function onRateLimitExceeded(RateLimitExceededEvent $event): void
-    {
-        // Extension-specific rate limit handling
-    }
-}
-```
-
-### Event Listener Registration Patterns
-
-#### Option 1: Direct Registration with Event::listen()
+## Class-Based Listener
 
 ```php
 namespace App\Listeners;
 
-use Glueful\Events\Event;
-use Glueful\Events\Auth\UserAuthenticatedEvent;
+use App\Events\OrderPlacedEvent;
+use Psr\Log\LoggerInterface;
 
-class SimpleAuthListener
+final class LogOrderPlacedListener
 {
-    public function register(): void
+    public function __construct(
+        private LoggerInterface $logger
+    ) {}
+
+    public function handle(OrderPlacedEvent $event): void
     {
-        // Register a single listener with priority
-        Event::listen(UserAuthenticatedEvent::class, [$this, 'handleLogin'], 10);
-
-        // Register using container service reference (lazy loading)
-        Event::listen(UserAuthenticatedEvent::class, '@analytics_service:trackLogin', 5);
-
-        // Register a closure
-        Event::listen(UserAuthenticatedEvent::class, function(UserAuthenticatedEvent $event) {
-            // Handle event inline
-        });
-    }
-
-    public function handleLogin(UserAuthenticatedEvent $event): void
-    {
-        // Handle the authentication event
+        $this->logger->info('Order placed', [
+            'order_id' => $event->orderId,
+            'total' => $event->total,
+        ]);
     }
 }
 ```
 
-#### Option 2: Event Subscriber Pattern (for multiple events)
+Register it:
 
 ```php
-namespace Glueful\Extensions\MyExtension;
+use App\Events\OrderPlacedEvent;
+use App\Listeners\LogOrderPlacedListener;
+use Glueful\Events\Event;
 
+Event::listen(OrderPlacedEvent::class, [LogOrderPlacedListener::class, 'handle']);
+```
+
+## Event Subscriber
+
+Use a subscriber when several listeners belong to the same domain.
+
+```php
+namespace App\Listeners;
+
+use App\Events\UserDeletedEvent;
+use App\Events\UserRegisteredEvent;
 use Glueful\Events\EventSubscriberInterface;
-use Glueful\Events\Auth\UserAuthenticatedEvent;
-use Glueful\Events\Database\QueryExecutedEvent;
-use Glueful\Events\Auth\RateLimitExceededEvent;
 
-class MyEventSubscriber implements EventSubscriberInterface
+final class UserLifecycleSubscriber implements EventSubscriberInterface
 {
-    /**
-     * Define subscribed events and their handlers
-     * This pattern is ideal when a single class handles multiple events
-     */
     public static function getSubscribedEvents(): array
     {
         return [
-            UserAuthenticatedEvent::class => [
-                ['onUserAuthenticated', 10],  // Priority 10
-                ['logAuthentication', 0]       // Priority 0
-            ],
-            QueryExecutedEvent::class => 'onQueryExecuted',
-            RateLimitExceededEvent::class => ['onRateLimitExceeded', 100]
+            UserRegisteredEvent::class => 'onRegistered',
+            UserDeletedEvent::class => 'onDeleted',
         ];
     }
-    
-    public function onUserAuthenticated(UserAuthenticatedEvent $event): void
+
+    public function onRegistered(UserRegisteredEvent $event): void
     {
-        // Handle authentication
+        // send welcome flow
     }
-    
-    public function logAuthentication(UserAuthenticatedEvent $event): void
+
+    public function onDeleted(UserDeletedEvent $event): void
     {
-        // Log authentication
-    }
-    
-    public function onQueryExecuted(QueryExecutedEvent $event): void
-    {
-        // Handle query execution
-    }
-    
-    public function onRateLimitExceeded(RateLimitExceededEvent $event): void
-    {
-        // Handle rate limit exceeded
+        // clean up downstream state
     }
 }
 ```
 
-#### Registering Subscribers
+## Queue Heavy Work
+
+Keep listeners fast. If a listener sends email, generates files, or calls external APIs, hand that work to the queue:
 
 ```php
+use Glueful\Queue\QueueManager;
+
+$queue = app($context, QueueManager::class);
+$queue->push(ProcessImageJob::class, [
+    'imageUuid' => $event->imageUuid,
+]);
+```
+
+## Add Logging
+
+```php
+use Psr\Log\LoggerInterface;
+
+$logger = app($context, LoggerInterface::class);
+$logger->info('User logged in', [
+    'user_id' => $event->userId,
+    'provider' => $event->provider,
+]);
+```
+
+## Create Event Classes
+
+Use the CLI scaffolds that exist today:
+
+```bash
+php glueful event:create UserRegistered
+php glueful event:listener SendWelcomeEmail
+```
+
+## Practical Pattern
+
+```php
+use App\Events\PasswordResetRequestedEvent;
 use Glueful\Events\Event;
+use Glueful\Queue\QueueManager;
 
-// Register the subscriber
-Event::subscribe(MyEventSubscriber::class);
+Event::listen(PasswordResetRequestedEvent::class, function (PasswordResetRequestedEvent $event) use ($context): void {
+    app($context, QueueManager::class)->push(SendPasswordResetEmailJob::class, [
+        'email' => $event->email,
+        'token' => $event->token,
+    ]);
+});
 ```
 
-**Note:** The Event Subscriber pattern (using `EventSubscriberInterface`) is preferred when:
-- A single class needs to handle multiple events
-- You want to define all event mappings in one place
-- You need different priorities for different handlers
-- Following the pattern used by framework listeners
-
-## Performance Monitoring
-
-### Event Performance Metrics
-
-```php
-namespace Glueful\Events\Monitoring;
-
-class EventPerformanceMonitor
-{
-    private array $metrics = [];
-    
-    public function startTiming(string $eventClass): void
-    {
-        $this->metrics[$eventClass]['start'] = microtime(true);
-    }
-    
-    public function endTiming(string $eventClass): void
-    {
-        if (isset($this->metrics[$eventClass]['start'])) {
-            $duration = microtime(true) - $this->metrics[$eventClass]['start'];
-            $this->metrics[$eventClass]['durations'][] = $duration;
-            
-            if ($duration > 0.1) { // 100ms threshold
-                $this->logSlowEventProcessing($eventClass, $duration);
-            }
-        }
-    }
-    
-    public function getAverageTime(string $eventClass): float
-    {
-        $durations = $this->metrics[$eventClass]['durations'] ?? [];
-        return count($durations) > 0 ? array_sum($durations) / count($durations) : 0.0;
-    }
-    
-    private function logSlowEventProcessing(string $eventClass, float $duration): void
-    {
-        logger()->warning('Slow event processing detected', [
-            'event_class' => $eventClass,
-            'duration' => $duration,
-            'threshold' => 0.1
-        ]);
-    }
-}
-```
-
-### Memory Usage Monitoring
-
-```php
-namespace Glueful\Events\Monitoring;
-
-class EventMemoryMonitor
-{
-    private int $baselineMemory;
-    
-    public function __construct()
-    {
-        $this->baselineMemory = memory_get_usage(true);
-    }
-    
-    public function checkMemoryUsage(string $eventClass): void
-    {
-        $currentMemory = memory_get_usage(true);
-        $memoryIncrease = $currentMemory - $this->baselineMemory;
-        
-        // Alert if memory increase is significant (> 10MB)
-        if ($memoryIncrease > 10 * 1024 * 1024) {
-            logger()->warning('High memory usage during event processing', [
-                'event_class' => $eventClass,
-                'memory_increase' => $memoryIncrease,
-                'current_memory' => $currentMemory,
-                'peak_memory' => memory_get_peak_usage(true)
-            ]);
-        }
-    }
-}
-```
+This keeps the controller focused on validation and response generation while the side effect runs separately.
 
 ## Best Practices
 
-### 1. Event Design
+- keep event payloads small and explicit
+- prefer immutable event data
+- do not hide critical synchronous behavior behind listeners
+- queue expensive listeners instead of blocking the request
+- log listener failures with enough context to retry safely
 
-**✅ Good Event Design**:
-```php
-class UserProfileUpdatedEvent extends BaseEvent
-{
-    public function __construct(
-        public readonly string $userId,
-        public readonly array $changes,
-        public readonly array $previousData,
-        public readonly ?string $updatedBy = null,
-        public readonly array $metadata = []
-    ) {}
-    
-    public function hasEmailChanged(): bool
-    {
-        return isset($this->changes['email']);
-    }
-    
-    public function wasProfilePictureUpdated(): bool
-    {
-        return isset($this->changes['profile_picture']);
-    }
-}
-```
+## Related
 
-**❌ Poor Event Design**:
-```php
-class UserEvent extends BaseEvent
-{
-    public $data; // Not readonly, not typed
-    public $action; // Unclear what this represents
-    
-    public function __construct($data, $action)
-    {
-        $this->data = $data;
-        $this->action = $action;
-    }
-}
-```
-
-### 2. Listener Implementation
-
-**✅ Good Listener**:
-```php
-class UserNotificationListener
-{
-    public function onUserProfileUpdated(UserProfileUpdatedEvent $event): void
-    {
-        try {
-            if ($event->hasEmailChanged()) {
-                $this->sendEmailChangeConfirmation($event->userId);
-            }
-            
-            if ($event->wasProfilePictureUpdated()) {
-                $this->updateProfilePictureCache($event->userId);
-            }
-        } catch (Exception $e) {
-            logger()->error('Failed to process user profile update', [
-                'user_id' => $event->userId,
-                'error' => $e->getMessage()
-            ]);
-            // Don't re-throw - listener failures shouldn't break main flow
-        }
-    }
-}
-```
-
-**❌ Poor Listener**:
-```php
-class BadListener
-{
-    public function handleEvent($event): void
-    {
-        // No type hints
-        // Doing too much in one listener
-        $this->sendEmail($event->data);
-        $this->updateDatabase($event->data);
-        $this->callExternalAPI($event->data);
-        $this->generateReport($event->data);
-        // No error handling
-    }
-}
-```
-
-### 3. Framework vs Application Separation
-
-**✅ Proper Separation**:
-```php
-// Framework: Detects and reports security violation
-use Glueful\Events\Event;
-
-class SecurityMiddleware
-{
-    public function handle(Request $request, Closure $next)
-    {
-        if ($this->rateLimiter->isExceeded($request->getClientIp())) {
-            $event = new RateLimitExceededEvent(/* ... */);
-            Event::dispatch($event);
-            return new Response('Rate limit exceeded', 429);
-        }
-        
-        return $next($request);
-    }
-}
-
-// Application: Responds with business logic
-class BusinessSecurityListener
-{
-    public function onRateLimitExceeded(RateLimitExceededEvent $event): void
-    {
-        // Business decision: How to respond to this violation
-        if ($this->isTrustedClient($event->clientIp)) {
-            // Increase limits for trusted clients
-            $this->rateLimiter->increaseLimit($event->clientIp);
-        } else {
-            // Apply business-specific penalties
-            $this->applySecurityPenalty($event);
-        }
-    }
-}
-```
-
-### 4. Performance Considerations
-
-```php
-// ✅ Lightweight event processing
-class PerformantListener
-{
-    public function onHeavyEvent(HeavyEvent $event): void
-    {
-        // Queue heavy processing instead of doing it synchronously
-        $this->queue->push(ProcessHeavyEventJob::class, [
-            'event_data' => $event->getEventData()
-        ]);
-    }
-}
-
-// ✅ Conditional processing
-class ConditionalListener
-{
-    public function onFrequentEvent(FrequentEvent $event): void
-    {
-        // Only process if certain conditions are met
-        if ($event->requiresProcessing()) {
-            $this->doProcessing($event);
-        }
-    }
-}
-```
-
-## Command Reference
-
-### Creating Events and Listeners
-
-```bash
-# Create a new event class
-php glueful event:create OrderShippedEvent
-
-# Create an event listener
-php glueful event:listener OrderShippedListener
-
-# Note: The following commands are available today
-php glueful event:create OrderShippedEvent
-php glueful event:listener OrderShippedListener
-
-# The following commands are not implemented in core yet and are subject to change
-# php glueful event:subscriber OrderEventSubscriber
-# php glueful event:list
-# php glueful event:debug UserAuthenticatedEvent
-```
-
-### Event System Diagnostics
-
-```bash
-# Planned diagnostics (not currently implemented)
-# php glueful event:monitor --duration=60s
-# php glueful event:stats
-# php glueful event:test UserAuthenticatedEvent
-# php glueful event:validate
-```
-
-<!-- Example output for planned diagnostics omitted until implemented. -->
-
-This comprehensive event system documentation provides the foundation for building robust, maintainable applications with clear separation between framework infrastructure and application business logic. The event-driven architecture enables powerful integration patterns while maintaining performance and reliability.
+- [Features: Events](/features/events)
+- [Features: Queues & Jobs](/features/queues-jobs)
+- [Cookbook: Queues & Jobs](/cookbook/queues-and-jobs)

--- a/content/6.cookbook/13.notifications.md
+++ b/content/6.cookbook/13.notifications.md
@@ -74,7 +74,7 @@ The `NotificationService` is the primary interface for notification management:
 ```php
 use Glueful\Notifications\Services\NotificationService;
 
-$notificationService = container()->get(NotificationService::class);
+$notificationService = container($context)->get(NotificationService::class);
 
 // Send notification
 $result = $notificationService->send(
@@ -111,7 +111,7 @@ Database operations and querying:
 ```php
 use Glueful\Repository\NotificationRepository;
 
-$repository = container()->get(NotificationRepository::class);
+$repository = container($context)->get(NotificationRepository::class);
 
 // Get user notifications
 // Fetch notifications for a notifiable (type + id)
@@ -355,8 +355,8 @@ use Glueful\Notifications\Contracts\Notifiable;
 class SlackChannel implements NotificationChannel
 {
     public function getChannelName(): string { return 'slack'; }
-    public function isAvailable(): bool { return (bool) config('notifications.channels.slack.enabled'); }
-    public function getConfig(): array { return config('notifications.channels.slack') ?? []; }
+    public function isAvailable(): bool { return (bool) config($context, 'notifications.channels.slack.enabled'); }
+    public function getConfig(): array { return config($context, 'notifications.channels.slack') ?? []; }
 
     public function format(array $data, Notifiable $notifiable): array
     {
@@ -379,7 +379,7 @@ class SlackChannel implements NotificationChannel
 
     public function send(Notifiable $notifiable, array $data): bool
     {
-        $webhookUrl = config('notifications.channels.slack.webhook_url');
+        $webhookUrl = config($context, 'notifications.channels.slack.webhook_url');
         $response = http_client()->post($webhookUrl, ['json' => $data]);
         return $response->getStatusCode() === 200;
     }
@@ -659,7 +659,7 @@ The {{app_name}} Team
 ```php
 use Glueful\Notifications\Templates\TemplateManager;
 
-$templateManager = container()->get(TemplateManager::class);
+$templateManager = container($context)->get(TemplateManager::class);
 
 // Render template with variables
 $rendered = $templateManager->renderTemplate('user_welcome', 'welcome', 'email', [
@@ -710,7 +710,7 @@ $notificationService->sendWithTemplate(
 ```php
 use Glueful\Notifications\Services\NotificationRetryService;
 
-$retryService = container()->get(NotificationRetryService::class);
+$retryService = container($context)->get(NotificationRetryService::class);
 
 // Queue a notification for retry after a failure
 $retryService->queueForRetry($notification, $user /* Notifiable */, 'email');
@@ -961,7 +961,7 @@ $this->analyticsService->trackNotificationEngagement($notification, $user);
 
 ```php
 // Use test channels in development
-if (config('app.env') === 'testing') {
+if (config($context, 'app.env') === 'testing') {
     $notificationService->setDefaultChannels(['test']);
 }
 

--- a/content/6.cookbook/14.file-uploads.md
+++ b/content/6.cookbook/14.file-uploads.md
@@ -10,23 +10,23 @@ This guide shows how to accept uploads securely, store them locally or on S3, an
 
 - Uploader class: `Glueful\Uploader\FileUploader`
 - Storage via `Glueful\Uploader\Storage\StorageInterface` with a Flysystem-backed implementation.
-  - Configure disks in `config('storage.disks.*')` (e.g., `uploads` for local, `s3` for Amazon S3)
-  - Select the default disk with `config('storage.default')` or env `STORAGE_DEFAULT_DISK`/`STORAGE_DRIVER`
+  - Configure disks in `config($context, 'storage.disks.*')` (e.g., `uploads` for local, `s3` for Amazon S3)
+  - Select the default disk with `config($context, 'storage.default')` or env `STORAGE_DEFAULT_DISK`/`STORAGE_DRIVER`
 - Safety: max file size, extension + MIME validation, basic hazard scanning, checksum utility
 - Utilities: directory statistics and cleanup
 
 ## Configuration
 
 ### Local paths
-- Upload root: `config('app.paths.uploads')`
-- CDN base URL: `config('app.urls.cdn')`
+- Upload root: `config($context, 'app.paths.uploads')`
+- CDN base URL: `config($context, 'app.urls.cdn')`
 
 ### File limits and validation
-- Max size: `config('filesystem.security.max_upload_size')`
+- Max size: `config($context, 'filesystem.security.max_upload_size')`
   - Env: `MAX_FILE_UPLOAD_SIZE` (bytes). Example: `10485760` (10MB)
-- Allowed extensions: `config('filesystem.file_manager.allowed_extensions')`
+- Allowed extensions: `config($context, 'filesystem.file_manager.allowed_extensions')`
   - Env: `FILE_ALLOWED_EXTENSIONS="jpg,jpeg,png,gif,pdf,doc,docx,txt"`
-- Hazard scanning: `config('filesystem.security.scan_uploads', true)`
+- Hazard scanning: `config($context, 'filesystem.security.scan_uploads', true)`
   - Looks for code markers in the first 64KB (basic safeguard)
 
 ### Amazon S3
@@ -39,7 +39,7 @@ This guide shows how to accept uploads securely, store them locally or on S3, an
   - `S3_SIGNED_URLS` (default `true`)
   - `S3_SIGNED_URL_TTL` (default `3600` seconds)
   - Optional CDN base: `S3_CDN_BASE_URL`
-- Mapping: these envs populate `config('storage.disks.s3.*')`
+- Mapping: these envs populate `config($context, 'storage.disks.s3.*')`
 
 #### Signed URLs
 - `FileUploader` returns a plain/public URL via the UrlGenerator (`base_url`/`cdn_base_url`) when you call `handleUpload(...)`.
@@ -52,8 +52,8 @@ use Glueful\Storage\Support\UrlGenerator;
 
 // Resolve shared services from the container and target the 's3' disk
 $storage = new FlysystemStorage(
-    app(StorageManager::class),
-    app(UrlGenerator::class),
+    app($context, StorageManager::class),
+    app($context, UrlGenerator::class),
     's3'
 );
 
@@ -137,7 +137,7 @@ Note: `handleBase64Upload` writes to a temporary file and returns its path. The 
 - Stats (count, size by type):
 
 ```php
-$stats = $uploader->getDirectoryStats(config('app.paths.uploads'));
+$stats = $uploader->getDirectoryStats(config($context, 'app.paths.uploads'));
 // ['exists' => true,
 //  'total_files' => 42,
 //  'total_size' => 123456,
@@ -149,7 +149,7 @@ $stats = $uploader->getDirectoryStats(config('app.paths.uploads'));
 - Cleanup old files (age in seconds):
 
 ```php
-$cleanup = $uploader->cleanupOldFiles(config('app.paths.uploads'), 86400); // 24h
+$cleanup = $uploader->cleanupOldFiles(config($context, 'app.paths.uploads'), 86400); // 24h
 // ['deleted_files' => N, 'freed_space' => bytes, 'freed_space_human' => '...']
 ```
 

--- a/content/6.cookbook/15.storage.md
+++ b/content/6.cookbook/15.storage.md
@@ -36,9 +36,9 @@ return [
         // Local filesystem
         'uploads' => [
             'driver' => 'local',
-            'root' => config('app.paths.uploads'),
+            'root' => config($context, 'app.paths.uploads'),
             'visibility' => 'private', // 'private' or 'public'
-            'base_url' => config('app.urls.cdn'), // Public URL base
+            'base_url' => config($context, 'app.urls.cdn'), // Public URL base
         ],
 
         // In-memory filesystem (great for testing)
@@ -95,9 +95,9 @@ return [
     'disks' => [
         'uploads' => [
             'driver' => 'local',
-            'root' => config('app.paths.uploads'),
+            'root' => config($context, 'app.paths.uploads'),
             'visibility' => 'public',
-            'base_url' => config('app.urls.cdn'), // e.g. https://cdn.example.com
+            'base_url' => config($context, 'app.urls.cdn'), // e.g. https://cdn.example.com
         ],
         's3' => [
             'driver' => 's3',
@@ -121,22 +121,22 @@ Resolve services:
 use Glueful\Storage\{StorageManager, PathGuard};
 use Glueful\Storage\Support\UrlGenerator;
 
-$storage = app(StorageManager::class);      // or app('storage')
-$guard   = app(PathGuard::class);          // Path validation service
-$urls    = app(UrlGenerator::class);       // URL generator service
+$storage = app($context, StorageManager::class);      // or app($context, 'storage')
+$guard   = app($context, PathGuard::class);          // Path validation service
+$urls    = app($context, UrlGenerator::class);       // URL generator service
 ```
 
-The provider also binds a convenient string alias: `app('storage')`.
+The provider also binds a convenient string alias: `app($context, 'storage')`.
 
 ## Common Tasks
 
 ### Choose a disk
 
 ```php
-$fs = app(StorageManager::class)->disk();        // default disk
-$s3 = app(StorageManager::class)->disk('s3');    // named disk
+$fs = app($context, StorageManager::class)->disk();        // default disk
+$s3 = app($context, StorageManager::class)->disk('s3');    // named disk
 
-if (!app(StorageManager::class)->diskExists('s3')) {
+if (!app($context, StorageManager::class)->diskExists('s3')) {
     // Log or fall back to default
 }
 ```
@@ -146,7 +146,7 @@ if (!app(StorageManager::class)->diskExists('s3')) {
 The `disk()` method returns a Flysystem `FilesystemOperator`, giving you access to all native Flysystem methods (v3):
 
 ```php
-$disk = app(StorageManager::class)->disk();
+$disk = app($context, StorageManager::class)->disk();
 
 // File operations
 if ($disk->fileExists('path/to/file.txt')) {
@@ -189,7 +189,7 @@ $readStream = $disk->readStream('uploads/large.dat');
 ### Write and read JSON
 
 ```php
-$storage = app(StorageManager::class);
+$storage = app($context, StorageManager::class);
 
 $storage->putJson('reports/daily.json', [
     'generated_at' => date(DATE_ATOM),
@@ -203,7 +203,7 @@ $data = $storage->getJson('reports/daily.json');
 
 ```php
 $fp = fopen('/path/to/bigfile', 'rb');
-app(StorageManager::class)->putStream('uploads/big.dat', $fp);
+app($context, StorageManager::class)->putStream('uploads/big.dat', $fp);
 ```
 
 This uses a temporary file strategy: writes to a `.tmp` file first, then atomically moves it into place. The temp file is cleaned up on failure.
@@ -211,7 +211,7 @@ This uses a temporary file strategy: writes to a `.tmp` file first, then atomica
 ### List contents
 
 ```php
-foreach (app(StorageManager::class)->listContents('backups', true) as $entry) {
+foreach (app($context, StorageManager::class)->listContents('backups', true) as $entry) {
     // $entry is a StorageAttributes instance
     $path = $entry->path();
     $isFile = $entry->isFile();
@@ -222,7 +222,7 @@ foreach (app(StorageManager::class)->listContents('backups', true) as $entry) {
 ### Generate public URLs
 
 ```php
-$urlGen = app(Glueful\Storage\Support\UrlGenerator::class);
+$urlGen = app($context, Glueful\Storage\Support\UrlGenerator::class);
 
 // Generate URL for a file
 $url = $urlGen->url('images/logo.png');
@@ -239,7 +239,7 @@ For time-limited access to private S3 objects, use the AWS SDK to generate a pre
 ```php
 use Glueful\Storage\Support\UrlGenerator;
 
-$cfg = app(UrlGenerator::class)->diskConfig('s3');
+$cfg = app($context, UrlGenerator::class)->diskConfig('s3');
 
 // Guard for availability
 if (class_exists(\Aws\S3\S3Client::class) && isset($cfg['bucket'])) {
@@ -278,8 +278,8 @@ use Glueful\Storage\{StorageManager};
 use Glueful\Storage\Support\UrlGenerator;
 
 $storage = new FlysystemStorage(
-    app(StorageManager::class),
-    app(UrlGenerator::class),
+    app($context, StorageManager::class),
+    app($context, UrlGenerator::class),
     's3'
 );
 
@@ -294,8 +294,8 @@ Notes:
 
 ```php
 // Get absolute path to storage directory
-$path = storage_path();                    // /path/to/project/storage
-$path = storage_path('logs/app.log');      // /path/to/project/storage/logs/app.log
+$path = storage_path($context, );                    // /path/to/project/storage
+$path = storage_path($context, 'logs/app.log');      // /path/to/project/storage/logs/app.log
 ```
 
 ## Path Safety
@@ -325,7 +325,7 @@ $path = storage_path('logs/app.log');      // /path/to/project/storage/logs/app.
 ### Manual Validation
 
 ```php
-$guard = app(Glueful\Storage\PathGuard::class);
+$guard = app($context, Glueful\Storage\PathGuard::class);
 
 try {
     // Validates and normalizes the path
@@ -346,13 +346,13 @@ Most `StorageManager` operations convert Flysystem exceptions to `StorageExcepti
 use Glueful\Storage\Exceptions\StorageException;
 
 try {
-    app(StorageManager::class)->getJson('missing/file.json');
+    app($context, StorageManager::class)->getJson('missing/file.json');
 } catch (StorageException $e) {
     $reason = $e->reason();      // Machine-readable reason code
     $status = $e->httpStatus();  // Suggested HTTP status code
 
     // Log with structured data
-    $logger = app('logger');
+    $logger = app($context, 'logger');
     $logger->error('Storage operation failed', [
         'reason' => $reason,
         'status' => $status,
@@ -393,7 +393,7 @@ $parsed = ExceptionClassifier::parseFromMessage($e->getMessage());
 ### Custom Disk at Runtime
 
 ```php
-$disk = app(StorageManager::class)->disk('uploads');
+$disk = app($context, StorageManager::class)->disk('uploads');
 
 // All Flysystem methods available
 $disk->write('file.txt', 'content');
@@ -409,7 +409,7 @@ if ($disk instanceof \League\Flysystem\Filesystem) {
 ### Working with Streams
 
 ```php
-$disk = app(StorageManager::class)->disk();
+$disk = app($context, StorageManager::class)->disk();
 
 // Read large file as stream
 $stream = $disk->readStream('large-file.zip');
@@ -429,7 +429,7 @@ $disk->writeStream('uploads/posted.dat', $input);
 ```php
 // StorageManager::putStream() is atomic by default
 $fp = fopen('critical-data.json', 'r');
-app(StorageManager::class)->putStream('config/settings.json', $fp);
+app($context, StorageManager::class)->putStream('config/settings.json', $fp);
 // Writes to temp file first, then moves atomically
 ```
 
@@ -446,7 +446,7 @@ app(StorageManager::class)->putStream('config/settings.json', $fp);
 
 ```php
 // In your test
-$storage = app(StorageManager::class)->disk('testing');
+$storage = app($context, StorageManager::class)->disk('testing');
 $storage->write('test.txt', 'content');
 // No actual filesystem writes!
 ```
@@ -489,9 +489,9 @@ rmdir($tempDir);
 
 ```php
 // Set test URLs
-config(['storage.disks.uploads.base_url' => 'https://cdn.test']);
+config($context, ['storage.disks.uploads.base_url' => 'https://cdn.test']);
 
-$url = app(UrlGenerator::class)->url('image.jpg', 'uploads');
+$url = app($context, UrlGenerator::class)->url('image.jpg', 'uploads');
 $this->assertEquals('https://cdn.test/image.jpg', $url);
 ```
 
@@ -521,4 +521,4 @@ $this->assertEquals('https://cdn.test/image.jpg', $url);
 
 ### Helper Functions
 
-- `storage_path(string $path = ''): string` - Get storage directory path
+- `storage_path($context, string $path = ''): string` - Get storage directory path

--- a/content/6.cookbook/16.image-processing.md
+++ b/content/6.cookbook/16.image-processing.md
@@ -16,7 +16,7 @@ image('/path/to/photo.jpg')
     ->save('/path/to/resized.jpg');
 
 // Using service injection
-$processor = app(ImageProcessorInterface::class);
+$processor = app($context, ImageProcessorInterface::class);
 $result = $processor::make('/path/to/photo.jpg')
     ->resize(800, 600)
     ->save('/path/to/resized.jpg');
@@ -121,10 +121,10 @@ use Glueful\Cache\CacheStore;
 
 // Resolve cache store
 /** @var CacheStore<mixed> $cache */
-$cache = app('cache.store');
+$cache = app($context, 'cache.store');
 
 // Compose full cache key used by ImageProcessor::cached()
-$prefix = (string) (config('image.cache.prefix', 'image_'));
+$prefix = (string) (config($context, 'image.cache.prefix', 'image_'));
 $key = $prefix . 'photo-800x600';
 
 // Try to serve from cache first
@@ -147,9 +147,9 @@ echo $imageData;
 
 ### Invalidate Cached Variant
 ```php
-$prefix = (string) (config('image.cache.prefix', 'image_'));
+$prefix = (string) (config($context, 'image.cache.prefix', 'image_'));
 $key = $prefix . 'photo-800x600';
-app('cache.store')->delete($key);
+app($context, 'cache.store')->delete($key);
 ```
 
 // Note: cached() stores the processed result under a cache key; retrieval and
@@ -209,7 +209,7 @@ public function uploadImage(Request $request): Response
     
     try {
         // Process uploaded file (use fromUpload for UploadedFileInterface)
-        $processedData = app(ImageProcessorInterface::class)
+        $processedData = app($context, ImageProcessorInterface::class)
             ::fromUpload($uploadedFile)
             ->resize(1200, 800)
             ->quality(85)
@@ -219,7 +219,7 @@ public function uploadImage(Request $request): Response
             
         // Save to storage
         $filename = 'processed_' . time() . '.webp';
-        file_put_contents(storage_path('images/' . $filename), $processedData);
+        file_put_contents(storage_path($context, 'images/' . $filename), $processedData);
         
         return Response::success(['filename' => $filename]);
         
@@ -233,7 +233,7 @@ public function uploadImage(Request $request): Response
 ```php
 // Create thumbnail variants from upload
 $uploadedFile = $request->getUploadedFiles()['image'];
-$processor = app(ImageProcessorInterface::class)::fromUpload($uploadedFile);
+$processor = app($context, ImageProcessorInterface::class)::fromUpload($uploadedFile);
 
 $sizes = [
     'thumbnail' => [150, 150],
@@ -251,7 +251,7 @@ foreach ($sizes as $size => $dimensions) {
         ->getImageData();
         
     $filename = "{$size}_" . time() . '.jpg';
-    file_put_contents(storage_path("images/{$filename}"), $processed);
+    file_put_contents(storage_path($context, "images/{$filename}"), $processed);
     $results[$size] = $filename;
 }
 ```

--- a/content/6.cookbook/17.distributed-locks.md
+++ b/content/6.cookbook/17.distributed-locks.md
@@ -16,7 +16,7 @@ Glueful now includes Symfony Lock component integration for distributed locking.
 use Glueful\Lock\LockManagerInterface;
 
 // Get lock manager from container
-$lockManager = container()->get(LockManagerInterface::class);
+$lockManager = container($context)->get(LockManagerInterface::class);
 
 // Simple lock
 $lock = $lockManager->createLock('my-resource');

--- a/content/6.cookbook/18.permissions-and-authorization.md
+++ b/content/6.cookbook/18.permissions-and-authorization.md
@@ -203,7 +203,7 @@ use Glueful\Permissions\Context;
 use Glueful\Auth\UserIdentity;
 
 // Get the Gate from container
-$gate = app(Gate::class);
+$gate = app($context, Gate::class);
 
 // Create user identity
 $user = new UserIdentity(
@@ -394,7 +394,7 @@ The `PermissionManager` integrates both provider-based and Gate-based authorizat
 ```php
 use Glueful\Permissions\PermissionManager;
 
-$manager = app('permission.manager');
+$manager = app($context, 'permission.manager');
 
 // Check permission (uses provider or Gate based on config)
 $canEdit = $manager->can(
@@ -448,11 +448,11 @@ public function boot()
 {
     $gate = $this->app->get(Gate::class);
 
-    if (config('app.multi_tenant')) {
+    if (config($context, 'app.multi_tenant')) {
         $gate->registerVoter(new TenantVoter());
     }
 
-    if (config('features.departments')) {
+    if (config($context, 'features.departments')) {
         $gate->registerVoter(new DepartmentVoter());
     }
 }
@@ -465,7 +465,7 @@ The system integrates with `PermissionCache`:
 ```php
 use Glueful\Permissions\PermissionCache;
 
-$cache = app(PermissionCache::class);
+$cache = app($context, PermissionCache::class);
 
 // Cache user permissions
 $cache->setUserPermissions('user-123', [
@@ -512,7 +512,7 @@ class BlogController
         $post = Post::find($id);
 
         // Additional ownership check
-        $gate = app(Gate::class);
+        $gate = app($context, Gate::class);
         $user = $this->getCurrentUserIdentity();
         $context = new Context(extra: ['ownerId' => $post->author_id]);
 
@@ -564,7 +564,7 @@ class ApiController
 {
     public function getData(Request $request)
     {
-        $gate = app(Gate::class);
+        $gate = app($context, Gate::class);
 
         // Build identity from JWT
         $user = new UserIdentity(
@@ -627,7 +627,7 @@ final class MyRbacProvider implements PermissionProviderInterface
 }
 
 // Register the provider
-$pm = app('permission.manager');
+$pm = app($context, 'permission.manager');
 $pm->setProvider(new MyRbacProvider());
 ```
 

--- a/content/6.cookbook/19.sessions-analytics.md
+++ b/content/6.cookbook/19.sessions-analytics.md
@@ -810,8 +810,8 @@ function generateActivityInsights($userActivity) {
 ### Current Configuration Points
 
 - Session TTL
-  - Default TTL comes from `config('session.access_token_lifetime')`.
-  - Per‑provider TTL from `config('security.authentication_providers.*.session_ttl')` (e.g., JWT/API key/OAuth).
+  - Default TTL comes from `config($context, 'session.access_token_lifetime')`.
+  - Per‑provider TTL from `config($context, 'security.authentication_providers.*.session_ttl')` (e.g., JWT/API key/OAuth).
 
 - Analytics cache
   - Analytics cache prefix is fixed to `session_analytics:`.
@@ -1042,8 +1042,8 @@ class SessionPerformanceOptimizer
 function getOptimizedAnalytics(array $filters = []): array
 {
     // Use DI cache store for caching
-    $cache = app('cache.store');
-    $analytics = app(Glueful\Auth\SessionAnalytics::class);
+    $cache = app($context, 'cache.store');
+    $analytics = app($context, Glueful\Auth\SessionAnalytics::class);
 
     $cacheKey = 'analytics:optimized:' . md5(json_encode($filters));
     if ($cached = $cache->get($cacheKey)) {
@@ -1065,7 +1065,7 @@ class MemoryOptimizedAnalytics
 {
     public function processLargeDataset(): array
     {
-        $sessionManager = app(Glueful\Auth\SessionCacheManager::class);
+        $sessionManager = app($context, Glueful\Auth\SessionCacheManager::class);
         $query = $sessionManager->sessionQuery()->whereProvider('jwt');
 
         $page = 1;

--- a/content/6.cookbook/2.middleware.md
+++ b/content/6.cookbook/2.middleware.md
@@ -327,7 +327,7 @@ class CacheMiddleware implements RouteMiddleware
         $cacheKey = $this->generateCacheKey($request, $varyBy);
         
         // Check cache
-        $cache = app(Glueful\Cache\CacheStore::class);
+        $cache = app($context, Glueful\Cache\CacheStore::class);
         if ($cached = $cache->get($cacheKey)) {
             return new Response($cached);
         }
@@ -532,7 +532,7 @@ $router->group(['middleware' => ['auth']], function($router) {
 To add your own string alias for middleware, load a binding into the container (e.g., during bootstrap or in a provider):
 
 ```php
-$container = app();
+$container = container($context);
 $container->load([
     // String alias => middleware instance (or factory/definition)
     'custom_rate_limit' => new App\Middleware\CustomRateLimitMiddleware(1000, 3600),
@@ -955,7 +955,7 @@ class DebugMiddleware implements RouteMiddleware
         $start = microtime(true);
         
         // Log middleware entry
-        logger()->debug('Middleware started', [
+        app($context, \Psr\Log\LoggerInterface::class)->debug('Middleware started', [
             'middleware' => static::class,
             'params' => $params,
             'request' => $request->getMethod() . ' ' . $request->getRequestUri()
@@ -964,7 +964,7 @@ class DebugMiddleware implements RouteMiddleware
         try {
             $response = $next($request);
             
-            logger()->debug('Middleware completed', [
+            app($context, \Psr\Log\LoggerInterface::class)->debug('Middleware completed', [
                 'middleware' => static::class,
                 'duration' => round((microtime(true) - $start) * 1000, 2) . 'ms',
                 'status' => method_exists($response, 'getStatusCode') 
@@ -975,7 +975,7 @@ class DebugMiddleware implements RouteMiddleware
             return $response;
             
         } catch (\Exception $e) {
-            logger()->error('Middleware failed', [
+            app($context, \Psr\Log\LoggerInterface::class)->error('Middleware failed', [
                 'middleware' => static::class,
                 'exception' => $e->getMessage(),
                 'trace' => $e->getTraceAsString()
@@ -994,7 +994,7 @@ class DebugMiddleware implements RouteMiddleware
 use Glueful\Routing\Middleware\AuthMiddleware;
 
 // Development - verbose logging, no expiration validation
-if (config('app.env') === 'development') {
+if (config($context, 'app.env') === 'development') {
     $devMiddleware = new AuthMiddleware(
         options: [
             'validate_expiration' => false,  // Skip expiration in dev
@@ -1009,7 +1009,7 @@ if (config('app.env') === 'development') {
 }
 
 // Production - full security features enabled
-if (config('app.env') === 'production') {
+if (config($context, 'app.env') === 'production') {
     $prodMiddleware = new AuthMiddleware(
         providerNames: ['jwt', 'api_key'],
         options: [
@@ -1152,7 +1152,7 @@ class AuthMiddlewareFactory
 }
 
 // Usage with factory
-$envMiddleware = AuthMiddlewareFactory::createForEnvironment(config('app.env'));
+$envMiddleware = AuthMiddlewareFactory::createForEnvironment(config($context, 'app.env'));
 $router->group(['middleware' => [$envMiddleware]], function($router) {
     $router->get('/api/user', 'UserController@index');
 });

--- a/content/6.cookbook/21.performance.md
+++ b/content/6.cookbook/21.performance.md
@@ -107,7 +107,7 @@ class UserService
     public function getProfile(int $userId): array
     {
         /** @var Glueful\\Cache\\CacheStore $cache */
-        $cache = app('cache.store');
+        $cache = app($context, 'cache.store');
         $key = "user_profile:$userId";
         return $cache->remember($key, function () use ($userId) {
             return $this->repository->getUserWithPermissions($userId);
@@ -285,13 +285,13 @@ class ResponsePerformanceMiddleware implements RouteMiddleware
         $duration = (microtime(true) - $start) * 1000;
 
         if ($response instanceof Response) {
-            if ((bool) config('app.debug', false)) {
+            if ((bool) config($context, 'app.debug', false)) {
                 $response->headers->set('X-Response-Time', sprintf('%.2fms', $duration));
                 $response->headers->set('X-Memory-Usage', (string) memory_get_usage(true));
             }
 
             if ($duration > 100) { // 100ms threshold
-                app('logger')->warning('Slow response detected', [
+                app($context, 'logger')->warning('Slow response detected', [
                     'url' => (string) $request->getUri(),
                     'duration_ms' => $duration,
                     'memory' => memory_get_usage(true)
@@ -351,7 +351,7 @@ class CacheMetrics
 
 ```php
 // Use profiling to identify bottlenecks
-$profiler = app()->get(ProfilerInterface::class);
+$profiler = container($context)->get(ProfilerInterface::class);
 $profiler->start('user_profile_generation');
 
 $profile = $this->userService->getProfile($userId);
@@ -1111,7 +1111,7 @@ The SessionAnalytics class provides comprehensive session tracking with performa
 use Glueful\Auth\SessionAnalytics;
 
 // Initialize analytics service
-$analytics = container()->get(SessionAnalytics::class);
+$analytics = container($context)->get(SessionAnalytics::class);
 
 // Get performance-optimized session metrics
 $metrics = $analytics->getSessionMetrics($userUuid);
@@ -1214,7 +1214,7 @@ The ApiMetricsService provides comprehensive API performance monitoring with opt
 use Glueful\Services\ApiMetricsService;
 
 // Initialize metrics service
-$metrics = container()->get(ApiMetricsService::class);
+$metrics = container($context)->get(ApiMetricsService::class);
 
 // Record API call (asynchronous)
 $metrics->recordApiCall($endpoint, $method, $responseTime, $statusCode, [

--- a/content/6.cookbook/22.console-commands.md
+++ b/content/6.cookbook/22.console-commands.md
@@ -846,26 +846,18 @@ php glueful generate:key --show
 
 ```bash
 # Generate basic controller
-php glueful generate:controller UserController
+php glueful scaffold:controller UserController
 
-# Generate REST API controller
-php glueful generate:controller UserController --api
-
-# Generate with specific methods
-php glueful generate:controller UserController --methods=index,show,store
+# Generate model and request classes
+php glueful scaffold:model User
+php glueful scaffold:request CreateUserRequest
 ```
 
 ### API Documentation
 
 ```bash
-# Generate API definitions
-php glueful generate:api-definitions
-
-# Generate API documentation
-php glueful generate:api-docs
-
-# Custom database and table
-php glueful generate:api-definitions --database=mydb --table=users
+# Generate OpenAPI documentation
+php glueful generate:openapi
 ```
 
 ### Event Scaffolding
@@ -982,13 +974,13 @@ $app->addCommand(MyCommand::class);
 
 ### Command Templates
 
-Glueful provides templates for common command patterns:
+Use a concrete scaffold command instead of a generic `generate:command` helper:
 
 ```bash
-# Create command from template
-php glueful generate:command MyCommand --template=basic
-php glueful generate:command MyCommand --template=database
-php glueful generate:command MyCommand --template=interactive
+# Create domain-specific classes with the scaffold commands that exist today
+php glueful scaffold:job SendDigestEmail
+php glueful scaffold:middleware EnsureAdmin
+php glueful scaffold:test UserControllerTest
 ```
 
 ## Best Practices
@@ -1153,8 +1145,8 @@ protected function execute(InputInterface $input, OutputInterface $output): int
     }
 
     // Access configuration
-    $timeout = config('app.timeout', 30);
-    $debug = config('app.debug', false);
+    $timeout = config($this->getContext(), 'app.timeout', 30);
+    $debug = config($this->getContext(), 'app.debug', false);
 
     return self::SUCCESS;
 }

--- a/content/6.cookbook/23.deployment.md
+++ b/content/6.cookbook/23.deployment.md
@@ -23,8 +23,6 @@ Essential checklist and tips for deploying Glueful services:
 - Warm up route cache/opcache during deploy
 - Run DB migrations and queue workers with supervision
 
----
-
 ## Table of Contents
 
 1. [Pre-Deployment Checklist](#pre-deployment-checklist)
@@ -820,7 +818,7 @@ public function comprehensive(): array
         'status' => $allHealthy ? 'healthy' : 'unhealthy',
         'timestamp' => date('c'),
         'checks' => $checks,
-        'version' => config('app.version')
+        'version' => config($context, 'app.version')
     ];
 }
 ```
@@ -981,8 +979,6 @@ configure_cdn() {
     enable_gzip_compression
 }
 ```
-
----
 
 This deployment guide provides comprehensive coverage for deploying Glueful applications across various environments. Choose the deployment strategy that best fits your infrastructure and requirements.
 

--- a/content/6.cookbook/25.testing.md
+++ b/content/6.cookbook/25.testing.md
@@ -15,10 +15,10 @@ What bootstrap does today:
 | Aspect | Behavior |
 | ------ | -------- |
 | Autoload | Locates Composer autoload in project or parent |
-| Container | Builds a minimal container and exposes it globally via `app()` helper |
+| Container | Builds a minimal container that you can access via `container($context)` or `app($context, Service::class)` |
 | Logging | Injects a mock logger (no file/db writes) |
 | Env Vars | `APP_ENV=testing`, in-memory sqlite (`:memory:`) via `DB_CONNECTION=sqlite`, disables file/db logging |
-| Helpers | Defines `config()`, `base_path()`, `app()` if not already defined |
+| Helpers | Defines `config($context, 'key')`, `base_path()`, and `app($context, Service::class)` if not already defined |
 | Timezone | Forces `UTC` for deterministic timestamps |
 | Directories | Ensures `tests/storage/cache` & `tests/storage/logs` exist |
 | Exception Handling | Puts `ExceptionHandler` (if present) into test mode |
@@ -112,8 +112,8 @@ Within tests you can leverage:
 
 | Helper | Purpose |
 | ------ | ------- |
-| `app()` | Access global container (set in bootstrap) |
-| `config()` | Returns minimal config values mocked in bootstrap |
+| `app($context, Service::class)` | Resolve a service from the bootstrapped container |
+| `config($context, 'key')` | Returns minimal config values mocked in bootstrap |
 | `base_path()` | Project root resolution |
 
 Use these when you need quick access without depending on full framework facades.

--- a/content/6.cookbook/3.di-and-services.md
+++ b/content/6.cookbook/3.di-and-services.md
@@ -36,17 +36,17 @@ Highlights:
 
 ```php
 // Using helpers
-$logger = app(Psr\Log\LoggerInterface::class);
-$cache  = app(Glueful\Cache\CacheStore::class);
-$router = app(Glueful\Routing\Router::class);
+$logger = app($context, Psr\Log\LoggerInterface::class);
+$cache  = app($context, Glueful\Cache\CacheStore::class);
+$router = app($context, Glueful\Routing\Router::class);
 
 // PSR-11 directly
-$c = container();
+$c = container($context);
 $database = $c->get('database'); // some services are string IDs
 
 // Optional access pattern
 if (has_service(Glueful\Auth\AuthenticationService::class)) {
-    $auth = app(Glueful\Auth\AuthenticationService::class);
+    $auth = app($context, Glueful\Auth\AuthenticationService::class);
 }
 ```
 
@@ -56,14 +56,14 @@ Notes:
 
 ### Resolution semantics
 
-- Class name: `app(Foo\Bar::class)` autowires constructor dependencies.
+- Class name: `app($context, Foo\Bar::class)` autowires constructor dependencies.
 - Aliases: string IDs (e.g., `'cache.store'`, `'database'`) resolve to services.
-- Interfaces: bind via alias so `app(Interface::class)` returns the implementation.
+- Interfaces: bind via alias so `app($context, Interface::class)` returns the implementation.
 - Parameters: inject via `#[Glueful\Container\Autowire\Inject(param: 'key')]` when autowiring, or read via `parameter('key')` inside a factory.
 
 ### Tags and tagged iterators
 
-Services may be tagged. Each tag is exposed as a container service of the same name that resolves to an array of instances ordered by `priority` descending. Example: `app('my.tag')` returns an array of tagged services.
+Services may be tagged. Each tag is exposed as a container service of the same name that resolves to an array of instances ordered by `priority` descending. Example: `app($context, 'my.tag')` returns an array of tagged services.
 
 Special lazy warmup tags:
 - `lazy.background` — warmed after the first response returns
@@ -209,7 +209,7 @@ final class CoreProvider extends BaseServiceProvider
         // Factory definition (shared)
         $defs['db.pool'] = new FactoryDefinition(
             'db.pool',
-            fn(\Psr\Container\ContainerInterface $c) => \Vendor\Db\Pool::fromConfig((array) config('database.pool', []))
+            fn(\Psr\Container\ContainerInterface $c) => \Vendor\Db\Pool::fromConfig((array) config($context, 'database.pool', []))
         );
 
         // String alias for convenience
@@ -217,7 +217,7 @@ final class CoreProvider extends BaseServiceProvider
 
         // Parameter/value style service
         $defs['feature.flags'] = new ValueDefinition('feature.flags', [
-            'beta' => (bool) config('app.beta', false),
+            'beta' => (bool) config($context, 'app.beta', false),
         ]);
 
         // Tag for lazy warmup (higher priority warms earlier)
@@ -425,8 +425,8 @@ Unit tests:
 - Construct services directly and pass mock dependencies.
 
 Integration tests:
-- Boot the framework to build the real container, then resolve services via `app()`.
-- For overrides, layer a child container with `container()->with([ Service::class => fn($c) => new FakeService(), ])` and inject it where appropriate (e.g., into console commands or your own entrypoints).
+- Boot the framework to build the real container, then resolve services via `app($context, Service::class)` or `container($context)->get(Service::class)`.
+- For overrides, load test-specific definitions with `container($context)->load([ Service::class => fn() => new FakeService(), ])`.
 
 ## Best Practices
 

--- a/content/6.cookbook/4.error-handling.md
+++ b/content/6.cookbook/4.error-handling.md
@@ -68,7 +68,7 @@ Response helpers:
 
 ### Global Exception Handling
 
-Glueful registers a global exception handler via `Glueful\\Exceptions\\ExceptionHandler::register()` during boot. It converts exceptions into standardized JSON error payloads, logs via PSR-3 (`app('logger')`) and adds context like request ID. You typically don't need a custom global handler—either throw domain exceptions or return explicit `Response::*` helpers.
+Glueful registers a global exception handler via `Glueful\\Exceptions\\ExceptionHandler::register()` during boot. It converts exceptions into standardized JSON error payloads, logs via PSR-3 (`app($context, 'logger')`) and adds context like request ID. You typically don't need a custom global handler—either throw domain exceptions or return explicit `Response::*` helpers.
 
 ```php
 <?php
@@ -1482,7 +1482,7 @@ class ErrorLogger
         
         // File handler for error logs
         $fileHandler = new RotatingFileHandler(
-            storage_path('logs/errors.log'),
+            storage_path($context, 'logs/errors.log'),
             7, // Keep 7 days
             Logger::ERROR
         );
@@ -2084,7 +2084,5 @@ describe('Error Handling', () => {
     });
 });
 ```
-
----
 
 This comprehensive error handling guide provides patterns and examples for robust error management in Glueful applications. Implement these patterns consistently across your application to provide a better developer and user experience.

--- a/content/6.cookbook/5.security.md
+++ b/content/6.cookbook/5.security.md
@@ -1,982 +1,178 @@
 ---
 title: Security Guide
-description: Authentication, permissions, CSRF, security headers, rate limiting, lockdown, and security CLI
+description: Practical security patterns for authentication, CSRF, rate limiting, headers, and production hardening.
 ---
 
-## Overview
+This page focuses on the parts of Glueful security that are both implemented in the framework and useful in day-to-day application code. Standalone snippets assume you already have an `ApplicationContext` available as `$context`.
 
-Glueful provides enterprise-grade security features that are fully implemented and production-ready. This guide covers the comprehensive security system that protects your application from common threats and vulnerabilities.
+## What Glueful Covers
 
-## Table of Contents
+- JWT-based authentication with persisted sessions
+- CSRF protection for browser-based flows
+- Rate limiting and abuse controls
+- Security middleware and headers
+- Production hardening and security CLI commands
 
-- [Security Architecture](#security-architecture)
-- [Vulnerability Scanner](#vulnerability-scanner)
-- [Authentication & Authorization](#authentication--authorization)
-- [Rate Limiting System](#rate-limiting-system)
-- [Session Security](#session-security)
-- [Security Middleware](#security-middleware)
-- [CSRF Protection](#csrf-protection)
-- [Security Headers](#security-headers)
-- [Emergency Lockdown](#emergency-lockdown)
-- [Security Monitoring](#security-monitoring)
-- [Security Configuration](#security-configuration)
-- [Security Commands](#security-commands)
-- [Production Security](#production-security)
+## Authentication and Sessions
 
-## Security Architecture
-
-### Multi-Layer Defense
-
-Glueful implements a comprehensive security architecture with multiple layers of protection:
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    Application Layer                        │
-│  • CSRF Protection  • Input Validation  • Authorization   │
-└─────────────────────────────────────────────────────────────┘
-┌─────────────────────────────────────────────────────────────┐
-│                    Framework Layer                          │
-│  • Rate Limiting  • Security Headers  • Authentication    │
-└─────────────────────────────────────────────────────────────┘
-┌─────────────────────────────────────────────────────────────┐
-│                  Infrastructure Layer                       │
-│  • Emergency Lockdown  • Vulnerability Scanner  • Audit   │
-└─────────────────────────────────────────────────────────────┘
-```
-
-### Core Security Components
-
-- **Vulnerability Scanner**: Automated security vulnerability detection
-- **Adaptive Rate Limiting**: Multi-dimensional request limiting with behavioral analysis
-- **JWT Authentication**: Dual-layer session storage (database + cache)
-- **CSRF Protection**: Double-submit pattern with configurable exemptions
-- **Security Headers**: Comprehensive security header middleware
-- **Emergency Lockdown**: Granular severity-based access control
-- **Session Analytics**: Advanced session monitoring and anomaly detection
-
-## Vulnerability Scanner
-
-Glueful includes a comprehensive vulnerability scanner that analyzes code, dependencies, and configuration for security issues.
-
-### Scanner Capabilities
-
-The vulnerability scanner detects:
-
-1. **Code Vulnerabilities**
-   - SQL injection patterns
-   - Cross-site scripting (XSS)
-   - Path traversal vulnerabilities
-   - Command injection
-   - Insecure direct object references
-
-2. **Dependency Vulnerabilities**
-   - Known CVEs in Composer packages
-   - Outdated dependencies with security issues
-   - Vulnerable JavaScript dependencies
-
-3. **Configuration Security**
-   - Environment configuration issues
-   - File permission problems
-   - Missing security headers
-   - Debug mode in production
-
-### Running Security Scans
-
-```bash
-# Full vulnerability scan
-php glueful security:scan
-
-# Scan specific component types
-php glueful security:scan --type=code
-php glueful security:scan --type=dependencies
-php glueful security:scan --type=config
-
-# Generate detailed reports
-php glueful security:vulnerabilities --format=json
-php glueful security:vulnerabilities --export=csv
-```
-
-### Scanner Output Example
-
-```bash
-$ php glueful security:scan
-
-Glueful Security Scanner
-=======================
-
-✓ Scanning code for vulnerabilities...
-✓ Checking dependencies...
-✓ Validating configuration...
-
-Results:
-========
-[HIGH] Potential SQL injection in UserController
-  File: api/Controllers/UserController.php:45
-  Issue: User input not properly sanitized
-  Recommendation: Use parameterized queries
-
-[MEDIUM] Outdated dependency detected
-  Package: guzzlehttp/guzzle 6.5.2
-  Issue: Known security vulnerability CVE-2022-29248
-  Recommendation: Update to version 7.4.3+
-
-[LOW] Missing security header
-  Issue: X-Content-Type-Options not configured
-  Recommendation: Enable in SecurityHeadersMiddleware
-
-Summary:
-- High: 1 issue
-- Medium: 1 issue  
-- Low: 1 issue
-- Security Score: 85/100
-```
-
-### Configuration
-
-```env
-# Vulnerability Scanner Settings
-VULNERABILITY_SCANNER_ENABLED=true
-SCANNER_AUTO_EXPORT=true
-SCANNER_HISTORICAL_TRACKING=true
-SCANNER_REPORT_FORMAT=json
-```
-
-## Authentication & Authorization
-
-### JWT Authentication with SessionStore (DB + Cache)
-
-Glueful uses a unified SessionStore to persist sessions in the database with cache acceleration. This provides a single, testable API for creating, updating, revoking, and reading sessions.
-
-#### SessionStoreInterface
+Glueful’s authentication flow is centered around the auth manager, token manager, and session store.
 
 ```php
 use Glueful\Auth\Interfaces\SessionStoreInterface;
 use Glueful\Auth\TokenManager;
-use Glueful\Auth\JWTService;
 
-/** @var SessionStoreInterface $store */
-$store = container()->get(SessionStoreInterface::class);
+$store = container($context)->get(SessionStoreInterface::class);
+$tokenManager = app($context, TokenManager::class);
 
-// Create token pair and persist a session
 $user = [
     'uuid' => $userUuid,
-    'username' => $username,
     'email' => $email,
+    'username' => $username,
 ];
 
-$accessTtl  = $store->getAccessTtl('jwt', false);
+$accessTtl = $store->getAccessTtl('jwt', false);
 $refreshTtl = $store->getRefreshTtl('jwt', false);
-$tokens     = TokenManager::generateTokenPair($user, $accessTtl, $refreshTtl);
+$tokens = $tokenManager->generateTokenPair($user, $accessTtl, $refreshTtl);
 
-$created = $store->create($user, $tokens, 'jwt', false);
-
-// Lookup by access token
-$session = $store->getByAccessToken($tokens['access_token']);
-
-// Rotate tokens (update)
-$newTokens = TokenManager::generateTokenPair($user, $accessTtl, $refreshTtl);
-$updated   = $store->updateTokens($tokens['refresh_token'], $newTokens);
-
-// Revoke session
-$revoked = $store->revoke($newTokens['access_token']);
-
-// Maintenance
-$cleanedCount = $store->cleanupExpired();
-
-// JWT verification (signature + exp)
-$ok = JWTService::verify($newTokens['access_token']);
+$store->create($user, $tokens, 'jwt', false);
 ```
 
-#### Session Analytics
+For authenticated controllers, prefer the built-in `BaseController` state instead of manually decoding tokens:
 
 ```php
-use Glueful\Auth\SessionAnalytics;
+use Glueful\Controllers\BaseController;
+use Glueful\Http\Response;
+use Symfony\Component\HttpFoundation\Request;
 
-$analytics = container()->get(SessionAnalytics::class);
+final class ProfileController extends BaseController
+{
+    public function show(Request $request): Response
+    {
+        if ($this->currentUser === null) {
+            return $this->unauthorized('Authentication required');
+        }
 
-// Get session metrics
-$metrics = $analytics->getSessionMetrics($userUuid);
-
-// Analyze session patterns
-$patterns = $analytics->analyzeSessionPatterns($userUuid);
-
-// Security assessment
-$riskScore = $analytics->calculateRiskScore($sessionId);
+        return $this->success([
+            'user' => $this->currentUser->toArray(),
+        ]);
+    }
+}
 ```
 
-#### Authentication Configuration
+## Registration and Credential Validation
 
-```env
-# JWT Configuration
-JWT_KEY=your-secure-256-bit-key
-ACCESS_TOKEN_LIFETIME=900    # 15 minutes
-REFRESH_TOKEN_LIFETIME=604800 # 7 days
-SESSION_LIFETIME=86400       # 24 hours
-
-# Session Storage
-SESSION_CACHE_ENABLED=true
-SESSION_CACHE_TTL=3600
-SESSION_DB_ENABLED=true
-```
-
-## Rate Limiting System
-
-Glueful implements sophisticated rate limiting with adaptive behavior and multiple dimensions.
-
-### Adaptive Rate Limiting
-
-The rate limiter analyzes user behavior and adjusts limits dynamically:
-
-```env
-# Rate Limiting Configuration
-RATE_LIMITING_ENABLED=true
-ADAPTIVE_RATE_LIMITING=true
-RATE_LIMIT_DRIVER=redis
-
-# Multiple Dimensions
-IP_RATE_LIMIT_MAX=100        # per minute
-USER_RATE_LIMIT_MAX=1000     # per hour
-ENDPOINT_RATE_LIMIT_MAX=50   # per minute
-
-# Adaptive Behavior
-RATE_LIMIT_BEHAVIOR_PROFILING=true
-RATE_LIMIT_MACHINE_LEARNING=false  # Statistical analysis used instead
-RATE_LIMIT_BURST_ALLOWANCE=2.0
-```
-
-### Rate Limiting in Action
-
-The rate limiter automatically:
-- Tracks request patterns per IP, user, and endpoint
-- Applies adaptive penalties for suspicious behavior
-- Integrates with the security event system
-- Provides detailed rate limit headers in responses
-
-### Rate Limit Headers
-
-```http
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1640995200
-```
-
-## Session Security
-
-### Session Monitoring
-
-Glueful provides comprehensive session security monitoring:
+For custom registration or password reset flows, validate request data before inserting or updating user records.
 
 ```php
-use Glueful\Auth\SessionAnalytics;
+use Glueful\Controllers\BaseController;
+use Glueful\Http\Response;
+use Glueful\Helpers\Utils;
+use Symfony\Component\HttpFoundation\Request;
 
-$analytics = container()->get(SessionAnalytics::class);
+final class RegistrationController extends BaseController
+{
+    public function register(Request $request): Response
+    {
+        $data = $this->getRequestData();
 
-// Monitor session for anomalies
-$anomalies = $analytics->detectAnomalies($sessionId);
+        if ($error = $this->validateRequest($data, [
+            'email' => 'required|email|max:255',
+            'password' => 'required|max:255',
+        ])) {
+            return $error;
+        }
 
-// Get session risk assessment
-$riskAssessment = $analytics->assessSessionRisk($sessionId);
+        $user = [
+            'uuid' => Utils::generateNanoID(),
+            'email' => $data['email'],
+            'password' => password_hash($data['password'], PASSWORD_BCRYPT),
+            'created_at' => date('Y-m-d H:i:s'),
+        ];
 
-// Track session behavior
-$behaviorProfile = $analytics->getSessionBehaviorProfile($userId);
+        $this->db->table('users')->insert($user);
+
+        unset($user['password']);
+
+        return $this->created(['user' => $user]);
+    }
+}
 ```
-
-### Session Configuration
-
-```env
-# Session Security
-SESSION_ANALYTICS_ENABLED=true
-SESSION_ANOMALY_DETECTION=true
-SESSION_RISK_SCORING=true
-SESSION_BEHAVIOR_TRACKING=true
-
-# Security Thresholds
-SUSPICIOUS_LOGIN_THRESHOLD=3
-SESSION_HIJACK_DETECTION=true
-UNUSUAL_LOCATION_ALERTS=true
-```
-
-## Security Middleware
-
-Glueful includes comprehensive security middleware that's automatically applied:
-
-### Available Middleware
-
-1. **AuthenticationMiddleware** - JWT token validation
-2. **AdminPermissionMiddleware** - Admin access control
-3. **RateLimiterMiddleware** - Request rate limiting
-4. **SecurityHeadersMiddleware** - Security headers
-5. **CSRFMiddleware** - CSRF protection
-
-### Middleware Stack
-
-The security middleware stack is automatically configured based on your environment and security settings.
 
 ## CSRF Protection
 
-### Double-Submit Pattern
+Use CSRF protection for browser forms and cookie-backed SPA flows. Retrieve a token from the built-in endpoint and send it back in a header or form field.
 
-Glueful implements CSRF protection using the double-submit cookie pattern:
-
-```php
-// CSRF token generation (automatic)
-$token = csrf_token();
-
-// Validation (automatic in middleware)
-// Tokens are validated from:
-// - HTTP headers (X-CSRF-TOKEN)
-// - Form fields (_token)
-// - JSON body (token)
+```http
+GET /csrf-token
 ```
 
-### CSRF Configuration
+Typical browser request:
+
+```http
+POST /profile
+X-CSRF-Token: <token>
+Cookie: csrf_token=<token>
+```
+
+If you need direct validation outside the built-in middleware, use the request helper and validator stack explicitly.
+
+## Rate Limiting
+
+Rate limiting should be stricter on login, OTP, and password reset endpoints than on ordinary authenticated API traffic.
+
+Recommended pattern:
+
+- Login: low per-minute threshold
+- OTP verification: stricter than login
+- Password reset: low threshold with cooldown
+- Authenticated application traffic: higher user-based limits
+
+See [Rate Limiting](/features/rate-limiting) for route-level examples.
+
+## Security Headers and Middleware
+
+Glueful ships with security-oriented middleware that should be enabled in production stacks:
+
+- `auth` for JWT/session-backed authentication
+- rate limiting middleware for abuse prevention
+- CSRF middleware for browser-facing writes
+- security headers middleware for CSP, HSTS, frame, and content-type protections
+
+Production baseline:
 
 ```env
-# CSRF Protection
-CSRF_PROTECTION_ENABLED=true
-CSRF_TOKEN_LIFETIME=3600
-CSRF_COOKIE_NAME=csrf_token
-CSRF_HEADER_NAME=X-CSRF-TOKEN
-
-# Route Exemptions
-CSRF_EXEMPT_ROUTES=api/webhooks,api/public
-```
-
-### CSRF in Forms
-
-```html
-<!-- Automatic token injection in forms -->
-<form method="POST" action="/submit">
-    <input type="hidden" name="_token" value="{{ csrf_token() }}">
-    <!-- form fields -->
-</form>
-```
-
-## Security Headers
-
-### Comprehensive Header Protection
-
-The SecurityHeadersMiddleware automatically adds security headers:
-
-```php
-// Headers automatically applied:
-// - Content-Security-Policy
-// - X-XSS-Protection: 1; mode=block
-// - X-Content-Type-Options: nosniff
-// - X-Frame-Options: DENY
-// - Referrer-Policy: strict-origin-when-cross-origin
-// - Strict-Transport-Security (HTTPS only)
-// - Permissions-Policy
-```
-
-### Security Headers Configuration
-
-```env
-# Security Headers
+APP_ENV=production
+APP_DEBUG=false
 SECURITY_HEADERS_ENABLED=true
-HSTS_MAX_AGE=31536000
-CSP_ENABLED=true
-CSP_REPORT_URI=/api/csp-report
-FRAME_OPTIONS=DENY
-```
-
-### Content Security Policy
-
-```env
-# CSP Configuration
-CSP_DEFAULT_SRC="'self'"
-CSP_SCRIPT_SRC="'self' 'unsafe-inline'"
-CSP_STYLE_SRC="'self' 'unsafe-inline'"
-CSP_IMG_SRC="'self' data: https:"
-CSP_FONT_SRC="'self'"
-CSP_CONNECT_SRC="'self'"
-CSP_MEDIA_SRC="'self'"
-CSP_OBJECT_SRC="'none'"
-```
-
-## Emergency Lockdown
-
-### Granular Lockdown System
-
-Glueful includes an emergency lockdown system with multiple severity levels:
-
-```bash
-# Enable lockdown with different severity levels
-php glueful security:lockdown --severity=low
-php glueful security:lockdown --severity=medium
-php glueful security:lockdown --severity=high
-php glueful security:lockdown --severity=critical
-
-# Disable lockdown
-php glueful security:lockdown --disable
-```
-
-### Lockdown Severity Levels
-
-1. **Low**: Restrict non-essential endpoints
-2. **Medium**: Allow only core functionality
-3. **High**: Emergency access only
-4. **Critical**: Complete lockdown (admin access only)
-
-### Lockdown Configuration
-
-```env
-# Emergency Lockdown
-LOCKDOWN_ENABLED=false
-LOCKDOWN_SEVERITY=medium
-LOCKDOWN_AUTO_RECOVERY=true
-LOCKDOWN_RECOVERY_TIME=3600  # 1 hour
-
-# IP Blocking
-LOCKDOWN_ENABLE_IP_BLOCKING=true
-LOCKDOWN_IP_BLOCK_THRESHOLD=10
-LOCKDOWN_IP_BLOCK_DURATION=1800
-
-# Notifications
-LOCKDOWN_WEBHOOK_URL=https://alerts.company.com/webhook
-LOCKDOWN_EMAIL_ALERTS=security@company.com
-```
-
-### Lockdown Status Check
-
-```bash
-# Check lockdown status
-php glueful security:check
-
-# Example output:
-Security Status: ACTIVE LOCKDOWN
-Severity Level: HIGH
-Lockdown Reason: Emergency security incident
-Auto-Recovery: Enabled (expires in 45 minutes)
-Blocked IPs: 3 addresses
-Restricted Endpoints: 15 routes
-```
-
-## Security Monitoring
-
-### Real-Time Security Events
-
-Glueful dispatches security events that you can listen to:
-
-```php
-// Available security events:
-// - CSRFViolationEvent
-// - RateLimitExceededEvent  
-// - SessionCreatedEvent
-// - SessionDestroyedEvent
-// - SecurityScanCompletedEvent
-```
-
-### Event Listeners
-
-```php
-use Glueful\Events\Security\RateLimitExceededEvent;
-
-$dispatcher->addListener(RateLimitExceededEvent::class, function($event) {
-    // Custom security response
-    if ($event->isSevereViolation()) {
-        // Enable emergency lockdown
-        $lockdownService->enableLockdown('high', 'Rate limit abuse detected');
-    }
-});
-```
-
-## Security Configuration
-
-### Main Security Configuration
-
-```php
-// config/security.php
-return [
-    'vulnerability_scanner' => [
-        'enabled' => env('VULNERABILITY_SCANNER_ENABLED', true),
-        'auto_export' => env('SCANNER_AUTO_EXPORT', true),
-        'historical_tracking' => env('SCANNER_HISTORICAL_TRACKING', true),
-    ],
-    
-    'rate_limiting' => [
-        'enabled' => env('RATE_LIMITING_ENABLED', true),
-        'adaptive' => env('ADAPTIVE_RATE_LIMITING', true),
-        'behavior_profiling' => env('RATE_LIMIT_BEHAVIOR_PROFILING', true),
-    ],
-    
-    'csrf' => [
-        'enabled' => env('CSRF_PROTECTION_ENABLED', true),
-        'token_lifetime' => env('CSRF_TOKEN_LIFETIME', 3600),
-        'exempt_routes' => explode(',', env('CSRF_EXEMPT_ROUTES', '')),
-    ],
-    
-    'headers' => [
-        'enabled' => env('SECURITY_HEADERS_ENABLED', true),
-        'hsts_max_age' => env('HSTS_MAX_AGE', 31536000),
-        'csp_enabled' => env('CSP_ENABLED', true),
-    ],
-];
-```
-
-### Lockdown Configuration
-
-```php
-// config/lockdown.php
-return [
-    'enabled' => env('LOCKDOWN_ENABLED', false),
-    'severity' => env('LOCKDOWN_SEVERITY', 'medium'),
-    'auto_recovery' => env('LOCKDOWN_AUTO_RECOVERY', true),
-    'recovery_time' => env('LOCKDOWN_RECOVERY_TIME', 3600),
-    
-    'ip_blocking' => [
-        'enabled' => env('LOCKDOWN_ENABLE_IP_BLOCKING', true),
-        'threshold' => env('LOCKDOWN_IP_BLOCK_THRESHOLD', 10),
-        'duration' => env('LOCKDOWN_IP_BLOCK_DURATION', 1800),
-    ],
-    
-    'notifications' => [
-        'webhook_url' => env('LOCKDOWN_WEBHOOK_URL'),
-        'email_alerts' => env('LOCKDOWN_EMAIL_ALERTS'),
-    ],
-];
+CSRF_ENABLED=true
+RATE_LIMITING_ENABLED=true
+JWT_KEY=replace-with-a-strong-secret
 ```
 
 ## Security Commands
 
-### Available Security Commands
+Use the CLI to verify production readiness and inspect vulnerabilities:
 
 ```bash
-# Vulnerability Management
-php glueful security:scan                    # Run vulnerability scan
-php glueful security:vulnerabilities         # List vulnerabilities
-php glueful security:check                   # Security health check
-
-# Lockdown Management  
-php glueful security:lockdown                # Manage emergency lockdown
-php glueful security:lockdown --severity=high
-php glueful security:lockdown --disable
-
-# Authentication & Sessions
-php glueful security:revoke-tokens           # Revoke user tokens
-php glueful security:reset-password          # Reset user passwords
-
-# Reporting
-php glueful security:report                  # Generate security report
+php glueful security:scan
+php glueful security:vulnerabilities --format=json
+php glueful system:production --check --score
 ```
 
-### Security Command Examples
-
-```bash
-# Comprehensive security check
-$ php glueful security:check
-
-Security Health Check
-====================
-✓ Vulnerability Scanner: Active
-✓ Rate Limiting: Enabled (Adaptive)
-✓ CSRF Protection: Active
-✓ Security Headers: Configured
-✓ Session Analytics: Active
-✗ Emergency Lockdown: Disabled
-⚠ SSL Certificate: Expires in 30 days
-
-Overall Security Score: 92/100
-```
-
-```bash
-# Emergency lockdown activation
-$ php glueful security:lockdown --severity=high --reason="Security incident"
-
-Emergency Lockdown Activated
-============================
-Severity: HIGH
-Reason: Security incident
-Restricted Endpoints: 15 routes
-Auto-Recovery: Enabled (60 minutes)
-IP Blocking: Active
-Notifications: Sent to security team
-```
-
-## Production Security
-
-### Production Security Validation
-
-Glueful includes production security validation to ensure your application is properly secured:
-
-```bash
-# Validate production security
-php glueful security:check --environment=production
-
-# Example output:
-Production Security Validation
-==============================
-✓ Environment: production
-✓ Debug Mode: Disabled
-✓ SSL/HTTPS: Enforced
-✓ Security Headers: Active
-✓ Rate Limiting: Configured
-✓ CSRF Protection: Enabled
-✓ JWT Keys: Secure (256-bit)
-✓ Database: SSL Enabled
-✗ Vulnerability Scanner: Not scheduled
-⚠ Session Timeout: Consider shorter timeout
-
-Security Score: 88/100
-
-Recommendations:
-1. Schedule daily vulnerability scans
-2. Reduce session timeout for production
-3. Enable additional rate limiting dimensions
-```
-
-### Production Security Checklist
-
-Before deploying to production, ensure:
-
-- [ ] `APP_ENV=production` and `APP_DEBUG=false`
-- [ ] Strong JWT keys generated (`php glueful generate:key`)
-- [ ] SSL/HTTPS enforced
-- [ ] Security headers enabled
-- [ ] CSRF protection active
-- [ ] Rate limiting configured
-- [ ] Vulnerability scanner scheduled
-- [ ] Emergency lockdown configured
-- [ ] Security monitoring enabled
-- [ ] Database SSL enabled
-
-### Environment-Specific Security
-
-```env
-# Production Security Settings
-APP_ENV=production
-APP_DEBUG=false
-
-# Strict Security
-SECURITY_LEVEL=strict
-RATE_LIMITING_STRICT_MODE=true
-CSRF_PROTECTION_STRICT=true
-SECURITY_HEADERS_STRICT=true
-
-# Monitoring
-VULNERABILITY_SCANNER_SCHEDULE=daily
-SECURITY_MONITORING_ENABLED=true
-SECURITY_ALERTS_EMAIL=security@company.com
-```
-
-## Security Best Practices
-
-### Development Security
-
-1. **Use the vulnerability scanner regularly**
-   ```bash
-   php glueful security:scan
-   ```
-
-2. **Test security configurations**
-   ```bash
-   php glueful security:check
-   ```
-
-3. **Monitor security events**
-   ```php
-   // Listen for security events
-   $dispatcher->addListener(SecurityEvent::class, $handler);
-   ```
-
-### Production Security
-
-1. **Enable all security features**
-   ```env
-   SECURITY_LEVEL=strict
-   ```
-
-2. **Schedule regular security scans**
-   ```bash
-   # Add to cron
-   0 2 * * * cd /path/to/app && php glueful security:scan
-   ```
-
-3. **Monitor security metrics**
-   ```bash
-   php glueful security:report --format=json
-   ```
-
-4. **Configure emergency procedures**
-   ```bash
-   # Test lockdown procedures
-   php glueful security:lockdown --test
-   ```
-
-## Summary
-
-Glueful provides a comprehensive, production-ready security framework that includes:
-
-- **Automated vulnerability scanning** with detailed reporting
-- **Adaptive rate limiting** with behavioral analysis
-- **Robust authentication** with dual-layer session storage
-- **Comprehensive CSRF protection** with configurable exemptions
-- **Security headers middleware** with modern security policies
-- **Emergency lockdown system** with granular severity levels
-- **Real-time security monitoring** with event-driven responses
-- **Production security validation** with automated checks
-
-All security features are fully implemented, tested, and ready for production use. The security system is designed to provide enterprise-grade protection while maintaining ease of use and configuration flexibility.# CSRF Protection Implementation Guide
-
-This document explains how to use the CSRF (Cross-Site Request Forgery) protection middleware in Glueful.
-
-## Overview
-
-The `CSRFMiddleware` protects against CSRF attacks by validating tokens for state-changing HTTP methods (POST, PUT, PATCH, DELETE). It provides:
-
-- Cryptographically secure token generation
-- Session-based token storage with cache fallback
-- Multiple token submission methods (header, form field, JSON)
-- Configurable exempt routes
-- Integration with existing authentication system
-
-## Quick Setup
-
-### 1. Add Middleware to Your Application
-
-```php
-// In your middleware stack or route configuration
-use Glueful\Http\Middleware\CSRFMiddleware;
-
-// Basic usage
-$app->add(new CSRFMiddleware());
-
-// With API route exemptions
-$app->add(CSRFMiddleware::withApiExemptions());
-
-// Custom configuration
-$app->add(new CSRFMiddleware(
-    exemptRoutes: ['api/webhooks/*', 'api/public/*'],
-    tokenLifetime: 3600, // 1 hour
-    useDoubleSubmit: false,
-    enabled: true
-));
-```
-
-### 2. Include CSRF Token in Forms
-
-```html
-<!-- HTML Forms -->
-<form method="POST" action="/api/users">
-    <?= \Glueful\Helpers\Utils::csrfField($request) ?>
-    <input type="text" name="username" required>
-    <button type="submit">Create User</button>
-</form>
-```
-
-### 3. Include CSRF Token in AJAX Requests
-
-```javascript
-// Get CSRF token data
-fetch('/api/csrf-token')
-    .then(response => response.json())
-    .then(data => {
-        // Store token for subsequent requests
-        window.csrfToken = data.token;
-        window.csrfHeader = data.header;
-    });
-
-// Use in AJAX requests
-fetch('/api/users', {
-    method: 'POST',
-    headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': window.csrfToken
-    },
-    body: JSON.stringify({
-        username: 'john_doe',
-        email: 'john@example.com'
-    })
-});
-```
-
-## Configuration Options
-
-### Constructor Parameters
-
-- `exemptRoutes` (array): Routes to exempt from CSRF protection
-- `tokenLifetime` (int): Token lifetime in seconds (default: 3600)
-- `useDoubleSubmit` (bool): Enable double-submit cookie pattern (default: false)
-- `enabled` (bool): Whether CSRF protection is enabled (default: true)
-
-### Environment Variables
-
-You can disable CSRF protection via environment:
-
-```env
-# .env
-CSRF_PROTECTION_ENABLED=true
-CSRF_TOKEN_LIFETIME=3600
-```
-
-## Token Submission Methods
-
-The middleware accepts CSRF tokens via:
-
-1. **HTTP Header** (recommended for AJAX): `X-CSRF-Token`
-2. **Form Field**: `_token`
-3. **Query Parameter**: `_token` (use with caution)
-4. **JSON Body**: `{"_token": "your-token"}`
-
-## Helper Functions
-
-### Utils::csrfToken(Request $request)
-Returns the current CSRF token:
-
-```php
-$token = \Glueful\Helpers\Utils::csrfToken($request);
-```
-
-### Utils::csrfField(Request $request)
-Returns HTML hidden input field:
-
-```php
-echo \Glueful\Helpers\Utils::csrfField($request);
-// Output: <input type="hidden" name="_token" value="abc123...">
-```
-
-### Utils::csrfTokenData(Request $request)
-Returns token data for JavaScript:
-
-```php
-$tokenData = \Glueful\Helpers\Utils::csrfTokenData($request);
-// Returns: ['token' => '...', 'header' => 'X-CSRF-Token', 'field' => '_token', 'expires_at' => timestamp]
-```
-
-## Creating a CSRF Token Endpoint
-
-Add this to your routes to provide tokens for JavaScript:
-
-```php
-// routes/api.php
-use Glueful\Http\Response;
-use Glueful\Helpers\Utils;
-
-Router::get('/csrf-token', function($params, $request) {
-    return Response::ok(Utils::csrfTokenData($request));
-});
-```
-
-## Exempt Routes
-
-Common routes to exempt from CSRF protection:
-
-```php
-$exemptRoutes = [
-    'api/auth/login',           // Login endpoint
-    'api/auth/register',        // Registration endpoint
-    'api/webhooks/*',           // Webhook endpoints
-    'api/public/*',             // Public API endpoints
-    'api/uploads/temp/*'        // Temporary upload endpoints
-];
-
-$middleware = new CSRFMiddleware($exemptRoutes);
-```
-
-## Security Considerations
-
-### Token Security
-- Tokens are cryptographically secure (32 hex characters)
-- Uses constant-time comparison to prevent timing attacks
-- Tokens expire after configured lifetime
-
-### Session Handling
-- Tokens are tied to user sessions when authenticated
-- Anonymous sessions use IP + User-Agent fingerprint
-- Cache-based storage for performance
-
-### Double-Submit Cookie Pattern
-Optional enhanced security:
-
-```php
-$middleware = new CSRFMiddleware(
-    useDoubleSubmit: true  // Enables cookie-based validation
-);
-```
-
-## Error Handling
-
-CSRF validation failures throw `SecurityException` with HTTP 419 status:
-
-```php
-try {
-    // Process request
-} catch (\Glueful\Exceptions\SecurityException $e) {
-    if ($e->getData()['error_code'] === 'CSRF_TOKEN_MISMATCH') {
-        // Handle CSRF failure
-        return Response::error('Please refresh and try again', 419);
-    }
-}
-```
-
-## Testing
-
-### Unit Tests
-```php
-public function testCSRFTokenGeneration()
-{
-    $request = new Request();
-    $middleware = new CSRFMiddleware();
-    
-    $token = $middleware->generateToken($request);
-    $this->assertNotEmpty($token);
-    $this->assertEquals(32, strlen($token));
-}
-```
-
-### Integration Tests
-```php
-public function testCSRFProtection()
-{
-    // Test that POST without token fails
-    $response = $this->post('/api/users', ['username' => 'test']);
-    $this->assertEquals(419, $response->getStatusCode());
-    
-    // Test that POST with valid token succeeds
-    $token = $this->getCSRFToken();
-    $response = $this->post('/api/users', [
-        'username' => 'test',
-        '_token' => $token
-    ]);
-    $this->assertEquals(201, $response->getStatusCode());
-}
-```
-
-## Best Practices
-
-1. **Always include CSRF tokens** in forms and AJAX requests
-2. **Use HTTPS** to prevent token interception
-3. **Set appropriate token lifetime** (balance security vs. UX)
-4. **Exempt only necessary routes** from CSRF protection
-5. **Handle CSRF failures gracefully** with user-friendly messages
-6. **Test CSRF protection** in your application tests
-
-## Troubleshooting
-
-### Common Issues
-
-**Token Mismatch Errors**:
-- Verify token is included in request
-- Check token hasn't expired
-- Ensure consistent session handling
-
-**Missing Tokens**:
-- Verify middleware is properly registered
-- Check exempt routes configuration
-- Ensure token generation for safe methods
-
-**AJAX Issues**:
-- Include `X-CSRF-Token` header
-- Get fresh token from `/csrf-token` endpoint
-- Handle token expiration in JavaScript
-
-### Debug Mode
-
-Enable debug logging to troubleshoot CSRF issues:
-
-```php
-// In development only
-$middleware = new CSRFMiddleware(
-    enabled: env('APP_ENV') === 'production'
-);
-```
+## Production Checklist
+
+- Disable debug mode
+- Use HTTPS everywhere
+- Set a strong `JWT_KEY`
+- Enable security headers
+- Enable rate limiting
+- Restrict admin and internal routes
+- Rotate secrets through environment management, not source control
+- Monitor auth failures and unusual session activity
+
+## Related Pages
+
+- [Authentication](/essentials/authentication)
+- [CORS & CSRF](/features/cors-csrf)
+- [Rate Limiting](/features/rate-limiting)
+- [Security Hardening](/deployment/security-hardening)

--- a/content/6.cookbook/6.configuration.md
+++ b/content/6.cookbook/6.configuration.md
@@ -8,7 +8,7 @@ description: Validate and normalize service options with Glueful’s internal Si
 
 Glueful provides an internal OptionsResolver (SimpleOptionsResolver) for robust service option validation. It delivers type‑safe defaults, validation, and normalization without requiring Symfony’s OptionsResolver.
 
-Tip: For application configuration (files under `config/`), use `config('key')` or `Glueful\Bootstrap\ConfigurationCache::get('key')` inside factories/services. Use the options resolver for per‑service runtime options.
+Tip: For application configuration (files under `config/`), use `config($context, 'key')` or `Glueful\Bootstrap\ConfigurationCache::get('key')` inside factories/services. Use the options resolver for per‑service runtime options.
 
 ## Quick Start
 

--- a/content/6.cookbook/8.database.md
+++ b/content/6.cookbook/8.database.md
@@ -58,7 +58,7 @@ Glueful's connection pooling system provides efficient connection management wit
 use Glueful\Database\Connection;
 
 // Recommended: use the framework connection (pooling is automatic if enabled in config)
-$db = container()->get('database'); // or: $db = new Connection();
+$db = container($context)->get('database'); // or: $db = new Connection();
 
 // Fluent query via QueryBuilder
 $results = $db
@@ -210,7 +210,7 @@ use Glueful\Database\QueryBuilder;
 // - QueryPurposeInterface: Tracks business purpose for logging/analysis
 
 // All components are injected via DI container
-$queryBuilder = container()->get(QueryBuilder::class);
+$queryBuilder = container($context)->get(QueryBuilder::class);
 ```
 
 ## Query Builder Advanced Features
@@ -280,7 +280,7 @@ $logs = $db
 use Glueful\Database\Connection;
 use Glueful\Database\QueryOptimizer;
 
-$db = container()->get(Connection::class);
+$db = container($context)->get(Connection::class);
 
 // Enable query optimization and caching
 $optimizedResults = $db->table('orders')
@@ -588,7 +588,7 @@ Glueful\\Database\\DevelopmentQueryMonitor::enable();
 use Glueful\Database\Tools\QueryProfilerService;
 
 // Sampling-based profiling for production
-// Configure via config('database.profiler'):
+// Configure via config($context, 'database.profiler'):
 // - sampling_rate (0.0–1.0)
 // - threshold (ms)
 $profiler = new QueryProfilerService();
@@ -655,7 +655,7 @@ Returns:
 ```php
 use Glueful\Database\Connection;
 
-$db = container()->get(Connection::class);
+$db = container($context)->get(Connection::class);
 
 // Add business context to queries for better debugging
 $userProfile = $db->table('users')
@@ -765,7 +765,7 @@ use Glueful\Database\Driver\MySQLDriver;
 use Glueful\Database\Driver\PostgreSQLDriver;
 use Glueful\Database\Driver\SQLiteDriver;
 
-$db = container()->get(Connection::class);
+$db = container($context)->get(Connection::class);
 
 // Database-agnostic query building
 $driver = $db->getDriver(); // Returns database-specific driver instance
@@ -823,7 +823,7 @@ use Glueful\Database\Migrations\MigrationManager;
 use Glueful\Database\Schema\Builders\SchemaBuilder;
 
 // Migration manager with batch tracking and checksum verification
-$migrationManager = container()->get(MigrationManager::class);
+$migrationManager = container($context)->get(MigrationManager::class);
 
 // Create a new migration
 $migrationManager->create('create_users_table');
@@ -930,7 +930,7 @@ $db->executeRaw(
 ```php
 use Glueful\Database\Connection;
 
-$db = container()->get(Connection::class);
+$db = container($context)->get(Connection::class);
 
 // Database-agnostic upsert using QueryBuilder
 // Automatically generates the correct SQL for MySQL, PostgreSQL, or SQLite
@@ -982,7 +982,7 @@ if ($db->getDriver() instanceof \Glueful\Database\Driver\MySQLDriver) {
 use Glueful\Database\Connection;
 use Glueful\Database\Features\SoftDeleteHandler;
 
-$db = container()->get(Connection::class);
+$db = container($context)->get(Connection::class);
 
 // Soft delete functionality is built into QueryBuilder
 // By default, delete() performs soft delete if enabled
@@ -1030,7 +1030,7 @@ $db->executeRaw('DELETE FROM users WHERE id = ?', [$userId]);
 
 // Configure soft delete column (if different from 'deleted_at')
 // This is typically configured at the application level
-$softDeleteHandler = container()->get(SoftDeleteHandler::class);
+$softDeleteHandler = container($context)->get(SoftDeleteHandler::class);
 $softDeleteHandler->setSoftDeleteColumn('archived_at');
 ```
 
@@ -1040,7 +1040,7 @@ $softDeleteHandler->setSoftDeleteColumn('archived_at');
 use Glueful\Database\Connection;
 use Glueful\Database\RawExpression;
 
-$db = container()->get(Connection::class);
+$db = container($context)->get(Connection::class);
 
 // Complex analytics queries with window functions (MySQL 8.0+, PostgreSQL)
 $salesAnalytics = $db->table('sales')
@@ -1095,7 +1095,7 @@ $performanceAnalysis = $db->table('employee_sales')
 use Glueful\Database\Connection;
 use Glueful\Database\Transaction\TransactionManager;
 
-$db = container()->get(Connection::class);
+$db = container($context)->get(Connection::class);
 
 // Automatic deadlock handling with retry
 $result = $db->table('orders')->transaction(function($db) use ($orderData, $inventoryUpdates) {
@@ -1127,7 +1127,7 @@ $result = $db->table('orders')->transaction(function($db) use ($orderData, $inve
 });
 
 // Alternative: Using TransactionManager directly for more control
-$transactionManager = container()->get(TransactionManager::class);
+$transactionManager = container($context)->get(TransactionManager::class);
 $transactionManager->setMaxRetries(3);
 
 $result = $transactionManager->transaction(function() use ($db, $orderData, $transactionManager) {
@@ -1155,7 +1155,7 @@ Prefer the high-level `$query->transaction(fn(...) => ...)` API. If you need exp
 ```php
 use Glueful\\Database\\Transaction\\TransactionManager;
 
-$tm = container()->get(TransactionManager::class);
+$tm = container($context)->get(TransactionManager::class);
 
 try {
     $tm->begin();
@@ -1563,10 +1563,10 @@ use Glueful\Database\QueryOptimizer;
 use Glueful\Database\Tools\ExecutionPlanAnalyzer;
 
 // 1. Use connection pooling in production (automatic when enabled in config)
-$db = container()->get(Connection::class); // Pooling is automatic if enabled
+$db = container($context)->get(Connection::class); // Pooling is automatic if enabled
 
 // Manual pool management (rarely needed)
-$poolManager = container()->get(ConnectionPoolManager::class);
+$poolManager = container($context)->get(ConnectionPoolManager::class);
 $pool = $poolManager->getPool('mysql');
 $connection = $pool->acquire();
 try {
@@ -1603,7 +1603,7 @@ foreach (array_chunk($records, $batchSize) as $batch) {
 }
 
 // 4. Monitor and analyze query performance
-$queryLogger = container()->get(QueryLogger::class);
+$queryLogger = container($context)->get(QueryLogger::class);
 $queryLogger->configure(
     enableDebug: false,     // Disable debug in production
     enableTiming: true,     // Track execution times

--- a/content/6.cookbook/9.validation.md
+++ b/content/6.cookbook/9.validation.md
@@ -166,7 +166,7 @@ Ensure a field is unique in a database table/column:
 use Glueful\Validation\Validator;
 use Glueful\Validation\Rules\{Required, Email, DbUnique};
 
-$pdo = app('database')->getPDO();
+$pdo = app($context, 'database')->getPDO();
 
 $rules = [
     'email' => [new Required(), new Email(), new DbUnique($pdo, 'users', 'email')]
@@ -198,5 +198,5 @@ if ($errors !== []) {
 - Validate associative arrays; the validator does not use attributes/DTO annotations
 - Apply sanitization via `Sanitize` as the first rule for a field
 - Keep error messages user-friendly in your API responses; rules return generic messages
-- For database-backed rules, reuse a long-lived PDO from the container (`app('database')->getPDO()`)
+- For database-backed rules, reuse a long-lived PDO from the container (`app($context, 'database')->getPDO()`)
 

--- a/content/7.api-reference.md
+++ b/content/7.api-reference.md
@@ -1,305 +1,113 @@
 ---
 title: API Reference
-description: Core API and helper functions reference
+description: Quick reference for common framework surfaces
 ---
 
-Quick reference for Glueful's core APIs and helper functions.
+This page is a compact reference for APIs you will use frequently in Glueful applications.
 
-## Global Helpers
-
-### app()
-Get service from container
+## Response Helpers
 
 ```php
-$db = app('database'); // or app(DatabaseInterface::class)
-$cache = app('cache'); // or app(CacheInterface::class)
+use Glueful\Http\Response;
+
+Response::success($data);
+Response::created($data);
+Response::noContent();
+Response::notFound('Not found');
+Response::unauthorized('Unauthorized');
+Response::forbidden('Forbidden');
+Response::validation(['field' => ['Message']]);
+Response::error('Server error', 500);
+Response::paginated($items, $total, $page, $perPage);
 ```
 
-### database (via container)
-Get database connection (no `db()` helper; use the container)
+## BaseController Helpers
+
+Inside controllers that extend `Glueful\Controllers\BaseController`:
 
 ```php
-$db = app('database'); // Glueful\Database\Connection
+$data = $this->getRequestData();
+$putData = $this->getPutData();
 
-// Query builder entrypoints
-$users = $db->table('users')->where('status', 'active')->get();
-$users = $db->query()->from('users')->where('status', 'active')->get();
-```
-
-### cache (via container)
-Get cache instance (no `cache()` helper; use the container)
-
-```php
-$cache = app('cache.store'); // or app(Glueful\Cache\CacheStore::class)
-$cache->set('key', 'value', 3600);
-$value = $cache->get('key');
-```
-
-### config()
-Get configuration value
-
-```php
-$appName = config('app.name');
-$dbHost = config('database.host');
-```
-
-### env()
-Get environment variable
-
-```php
-$apiKey = env('API_KEY');
-$debug = env('APP_DEBUG', false);
-```
-
-### logger (via container)
-Get logger instance (no `logger()` helper; use the container)
-
-```php
-$logger = app('logger'); // or app(Psr\Log\LoggerInterface::class)
-$logger->info('Message', ['context' => 'value']);
-$logger->error('Error occurred', ['error' => $e->getMessage()]);
+return $this->success($data);
+return $this->created($data);
+return $this->notFound('Missing');
 ```
 
 ## Database
 
-### Query Builder
+`BaseController` exposes `$this->db`:
 
 ```php
-// Entrypoints
-$db = app('database');
-$db->table('users')->get();
-$db->table('users')->where('status', 'active')->get();
-
-// Insert/Update/Delete (return ints)
-$db->table('users')->insert(['name' => 'John', 'email' => 'john@example.com']);
-$db->table('users')->where('id', $id)->update(['name' => 'Jane']);
-$db->table('users')->where('id', $id)->delete();
-
-// Using query()->from(...)
-$db->query()->from('users')->select(['id','name'])->get();
-
-// Joins
-$db->query()
-    ->from('users')
-    ->join('orders', 'users.id', '=', 'orders.user_id')
-    ->select(['users.*', 'orders.total'])
-    ->get();
-
-// Aggregates
-$db->query()->from('orders')->count();
-$db->query()->from('orders')->max('total');
-
-// Pagination
-$db->query()->from('orders')->paginate(page: 1, perPage: 15);
-
-// Optional: enable query result caching
-$db->query()->from('users')->where('active', 1)->cache(3600)->get();
+$users = $this->db->table('users')->get();
+$user = $this->db->table('users')->where('id', 1)->first();
+$id = $this->db->table('users')->insert(['name' => 'John']);
+$this->db->table('users')->where('id', 1)->update(['name' => 'Jane']);
+$this->db->table('users')->where('id', 1)->delete();
 ```
-
-See [Database Guide](/essentials/database) for full reference.
-
-## Cache
-
-```php
-// Set
-$cache = app('cache.store');
-$cache->set('key', 'value', 3600);
-
-// Get
-$value = $cache->get('key');
-$value = $cache->get('key', 'default');
-
-// Remember pattern (pseudo if implemented)
-$users = $cache->remember('users:active', function() use ($db) {
-    return $db->table('users')->where('status', 'active')->get();
-}, 3600);
-
-// Check existence
-if ($cache->has('key')) { /* ... */ }
-
-// Delete
-$cache->delete('key');
-// $cache->deletePattern('users:*'); // If pattern deletion supported by driver (Redis/File)
-
-// Clear all
-$cache->clear();
-```
-
-See [Caching Guide](/features/caching) for full reference.
-
-## Queue
-
-```php
-// Obtain queue manager
-$queue = app('queue'); // or app(Glueful\Queue\QueueManager::class)
-
-// Push job (use job class name + payload)
-$queue->push(SendEmailJob::class, ['userId' => $userId]);
-
-// Delayed job
-$queue->later(60, ProcessImageJob::class, ['path' => $path]);
-
-// Push to specific queue
-$queue->push(SendEmailJob::class, ['userId' => $userId], queue: 'emails');
-
-// Bulk
-$queue->bulk([
-    ['job' => Job1::class, 'data' => ['id' => 1]],
-    ['job' => Job2::class, 'data' => ['id' => 2]],
-]);
-```
-
-See [Queues & Jobs Guide](/features/queues-jobs) for full reference.
-
-## Events
-
-```php
-// Dispatch (using event dispatcher service)
-app(Glueful\Events\EventDispatcher::class)->dispatch(new UserRegistered($user));
-
-// Listener registration typically happens via service providers / attributes.
-// Inline listening (if supported) would use dispatcher subscribe API.
-```
-
-See [Events Guide](/features/events) for full reference.
-
-## HTTP
-
-### Request
-
-```php
-$request->getMethod();                // GET, POST, etc.
-$request->getPathInfo();              // /api/users
-$request->getUri();                   // Full URI
-$request->get('name');                // Single input value
-$request->request->all();             // POST body params
-// Selecting specific fields:
-$data = $request->request->all();
-$subset = array_intersect_key($data, array_flip(['name','email']));
-isset($data['name']);                 // Existence check
-$request->files->get('avatar');       // Uploaded file
-$request->headers->get('Authorization'); // Header
-$request->getClientIp();              // Client IP
-$request->headers->get('User-Agent'); // User agent
-// Authenticated user (via auth helper/service)
-$authUser = auth()?->user(); // or app(Glueful\Auth\AuthenticationService::class)->getCurrentUser()
-```
-
-### Response
-
-```php
-// Success
-Response::success($data);
-Response::created($data); // 201 Created
-
-// Error
-Response::error('Not found', 404);
-Response::error('Validation failed', 422, ['errors' => $errors]);
-
-// Headers
-$resp = Response::success($data)->header('X-Custom', 'value');
-```
-
-See [Requests & Responses Guide](/essentials/requests-responses) for full reference.
 
 ## Validation
 
+Simple controller validation:
+
 ```php
-// Rule-object validation via ValidatorInterface
-use Glueful\Helpers\RequestHelper;
+if ($error = $this->validateRequest($data, [
+    'email' => 'required|email|max:255',
+])) {
+    return $error;
+}
+```
+
+Rule-object validation:
+
+```php
 use Glueful\Validation\Validator;
-use Glueful\Validation\Rules\{Required, Type, Length, Email, Range};
+use Glueful\Validation\Rules\Required;
 
-$input = RequestHelper::getRequestData($request);
+$validator = new Validator([
+    'name' => [new Required()],
+]);
 
-$rules = [
-    'name' => [new Required(), new Type('string'), new Length(min: 3, max: 255)],
-    'email' => [new Required(), new Email()],
-    'password' => [new Required(), new Length(min: 8)],
-    'age' => [new Required(), new Type('integer'), new Range(min: 18)],
-];
-
-$validator = new Validator($rules);
 $errors = $validator->validate($input);
-if ($errors !== []) {
-    return Response::validation($errors);
+```
+
+## Routing Attributes
+
+```php
+use Glueful\Routing\Attributes\Controller;
+use Glueful\Routing\Attributes\Get;
+use Glueful\Routing\Attributes\Route;
+
+#[Controller(prefix: '/v1/users')]
+class UserController
+{
+    #[Get('/{id}', where: ['id' => '\d+'])]
+    public function show(int $id): \Glueful\Http\Response
+    {
+        return \Glueful\Http\Response::success(['id' => $id]);
+    }
+
+    #[Route('/search', methods: 'GET')]
+    public function search(): \Glueful\Http\Response
+    {
+        return \Glueful\Http\Response::success([]);
+    }
 }
 ```
 
-### Available Rules (objects)
+## CLI
 
-- `Required` - Field must be present
-- `Type('string'|'integer'|...)` - Type check
-- `Length(min?, max?)` - String length
-- `Range(min?, max?)` - Numeric range
-- `Email()` - Valid email
-- `InArray([...])` - Must be in list
-- `DbUnique(...)` - Database uniqueness
-- `Sanitize(...)` - Value sanitization
+Current commonly used commands:
 
-See [Validation Guide](/essentials/validation) for full reference.
-
-## Authentication
-
-```php
-$authService = app(Glueful\Auth\AuthenticationService::class);
-
-// Login (username or email)
-$session = $authService->authenticate(['username' => $email, 'password' => $password]);
-
-// Get authenticated user (object) from context
-$user = auth()?->user();
-
-// Check authentication
-if (auth()?->check()) {
-    // Authenticated
-}
-
-// Logout / terminate session
-$authService->terminateSession($token);
+```bash
+php glueful install
+php glueful serve
+php glueful migrate:run
+php glueful migrate:status
+php glueful scaffold:controller UserController
+php glueful scaffold:model User
+php glueful scaffold:request CreateUserRequest
+php glueful generate:key
+php glueful generate:openapi
+php glueful cache:clear
 ```
-
-See [Authentication Guide](/essentials/authentication) for full reference.
-
-## File Storage
-
-```php
-// Storage via services
-$storage = app(Glueful\Storage\StorageManager::class);
-$disk = $storage->disk(); // default disk from config
-
-// Write/read using Flysystem operator
-$disk->write('avatars/user-1.png', $binaryContents);
-$contents = $disk->read('avatars/user-1.png');
-if ($disk->fileExists('avatars/user-1.png')) { /* ... */ }
-$disk->delete('avatars/user-1.png');
-
-// JSON helpers
-$storage->putJson('data/users/1.json', ['id' => 1]);
-$data = $storage->getJson('data/users/1.json');
-
-// Public URL
-$url = app(Glueful\Storage\Support\UrlGenerator::class)
-    ->url('avatars/user-1.png');
-```
-
-See [File Uploads Guide](/features/file-uploads) for full reference.
-
-## Logging
-
-```php
-logger()->debug('Debug info', ['data' => $data]);
-logger()->info('Info message', ['user_id' => $userId]);
-logger()->warning('Warning', ['key' => $key]);
-logger()->error('Error occurred', ['error' => $e->getMessage()]);
-logger()->critical('Critical failure');
-```
-
-See [Logging Guide](deployment/logging) for full reference.
-
-## Next Steps
-
-- [CLI Reference](cli-reference) - Command-line tools
-- [Essentials](essentials/) - Core concepts
-- [Features](features/) - Framework features
-- [Advanced](advanced/) - Advanced topics

--- a/content/8.cli-reference.md
+++ b/content/8.cli-reference.md
@@ -1,669 +1,152 @@
 ---
 title: CLI Reference
-description: Complete Glueful command-line interface reference
+description: Reference for common Glueful CLI commands
 ---
 
-Complete reference for all Glueful CLI commands.
+This reference focuses on commands that exist in the current framework and starter app.
 
-## Getting Started
+## Basics
 
 ```bash
-# List all commands (installed via Composer)
- php glueful
-
-# Get help for a command
- php glueful help <command>
-
-# List commands by namespace
- php glueful list extensions
- php glueful list security
- php glueful list system
+php glueful
+php glueful help serve
+php glueful list
 ```
 
-## Database & Migrations
-
-### migrate:run
-Run pending migrations
+## Setup
 
 ```bash
- php glueful migrate:run
- php glueful migrate:run --force   # Skip confirmation in production
- php glueful migrate:run --dry-run # Show operations without running
-```
-
-### migrate:rollback
-Rollback the last migration batch
-
-```bash
- php glueful migrate:rollback
- php glueful migrate:rollback --steps=2   # Rollback N steps
- php glueful migrate:rollback --dry-run   # Preview rollbacks
-```
-
-### migrate:status
-Show migration status
-
-```bash
- php glueful migrate:status
-```
-
-### migrate:create
-Create a new migration
-
-```bash
- php glueful migrate:create CreateUsersTable
-```
-
-### db:reset
-Drop all tables (use with care)
-
-```bash
- php glueful db:reset
- php glueful db:reset --dry-run  # Preview tables to be dropped
- php glueful db:reset --force    # Skip confirmations
-```
-
-### db:status
-Show database status and connectivity
-
-```bash
- php glueful db:status
-```
-
-### db:profile
-Profile slow queries and database health
-
-```bash
- php glueful db:profile
-```
-
-## Queue & Jobs
-
-### queue:work
-Start and manage workers (multi-worker)
-
-```bash
-# Default (2 workers on 'default' queue)
- php glueful queue:work
-
-# Queues and worker count
- php glueful queue:work --queue=emails,reports --workers=4
-
-# Limits and behavior
- php glueful queue:work --memory=256 --timeout=90 --max-jobs=1000 --stop-when-empty
-
-# Other actions
- php glueful queue:work status --json
- php glueful queue:work spawn --count=2 --queue=emails
- php glueful queue:work restart --all
-```
-
-### queue:autoscale
-Auto-scale workers with monitoring and scheduling
-
-```bash
- php glueful queue:autoscale               # Run autoscaler
- php glueful queue:autoscale status --json # Show status as JSON
- php glueful queue:autoscale config --show --validate
- php glueful queue:autoscale schedule --list --preview --days=7
-```
-
-### queue:scheduler
-Advanced job scheduling and management system
-
-```bash
-# Run the scheduler
- php glueful queue:scheduler
-```
-
-## Cache
-
-### cache:clear
-Clear application cache
-
-```bash
- php glueful cache:clear
-```
-
-### cache:delete
-Remove specific cache key
-
-```bash
- php glueful cache:delete users:active
-```
-
-### cache:get
-Get cache value
-
-```bash
- php glueful cache:get users:active
-```
-
-### cache:set
-Set cache value
-
-```bash
- php glueful cache:set users:active '{"ids":[1,2,3]}' --ttl=3600
-```
-
-### cache:ttl
-Show TTL for a key
-
-```bash
- php glueful cache:ttl users:active
-```
-
-### cache:expire
-Expire a key in N seconds
-
-```bash
- php glueful cache:expire users:active 120
-```
-
-### cache:status
-Show cache driver status and capabilities
-
-```bash
- php glueful cache:status
-```
-
-### cache:purge
-Clear all cache entries (driver-specific)
-
-```bash
- php glueful cache:purge
-```
-
-### cache:maintenance
-Run or queue cache maintenance tasks
-
-```bash
- php glueful cache:maintenance
+php glueful install
+php glueful generate:key
+php glueful doctor
+php glueful system:check
 ```
 
 ## Development Server
 
-### serve
-Start development server
-
 ```bash
-# Default: localhost:8000
- php glueful serve
-
-# Custom host and port
- php glueful serve --host=0.0.0.0 --port=9000
-
-# Open in browser
- php glueful serve --open
-```
-
-## Code Generation
-
-### generate:controller
-Generate a REST API controller from template
-
-```bash
- php glueful generate:controller UserController
- php glueful generate:controller Api/UserController  # Nested
-```
-
-### generate:key
-Generate secure encryption keys for the framework
-
-```bash
- php glueful generate:key
-```
-
-### generate:api-definitions
-Generate OpenAPI/route definitions
-
-```bash
- php glueful generate:api-definitions
-```
-
-### event:create
-Create a new event class
-
-```bash
- php glueful event:create UserRegistered
-```
-
-### event:listener
-Create a new event listener class
-
-```bash
- php glueful event:listener SendWelcomeEmail
-```
-
-### create:extension
-Create new local extension
-
-```bash
- php glueful create:extension MyExtension
-```
-
-## Extensions
-
-```bash
- php glueful extensions:list
- php glueful extensions:info <slug>
- php glueful extensions:enable <slug>
- php glueful extensions:disable <slug>
- php glueful extensions:cache
- php glueful extensions:clear
- php glueful extensions:summary
- php glueful extensions:why <Provider\Class>
-```
-
-## System
-
-```bash
- php glueful install
- php glueful system:check
- php glueful system:production
- php glueful system:memory
- php glueful version
-```
-
-## Container (DI)
-
-```bash
- php glueful di:container:debug
- php glueful di:container:compile
- php glueful di:container:validate
- php glueful di:lazy:status
-```
-
-## Security
-
-```bash
- php glueful security:check
- php glueful security:scan
- php glueful security:vulnerabilities
- php glueful security:lockdown
- php glueful security:reset-password --email=user@example.com
- php glueful security:report
- php glueful security:revoke-tokens --all
-```
-
-## Inspection & Debugging
-
-### route:list
-List all registered routes
-
-```bash
-php glueful route:list
-
-# Filter by method
-php glueful route:list --method=POST
-
-# Filter by path
-php glueful route:list --path=/api/users
-```
-
-### config:show
-Display configuration values
-
-```bash
-# Show all config
-php glueful config:show
-
-# Show specific config
-php glueful config:show database
-```
-
-### env:check
-Validate .env configuration
-
-```bash
-php glueful env:check
-```
-
-## Maintenance
-
-### down
-Put application in maintenance mode
-
-```bash
-php glueful down
-php glueful down --message="Scheduled maintenance"
-```
-
-### up
-Bring application out of maintenance mode
-
-```bash
-php glueful up
-```
-
-### optimize
-Optimize the framework for better performance
-
-```bash
-php glueful optimize
-```
-
-## Security
-
-### security:check
-Check security configuration and show issues
-
-```bash
-php glueful security:check
-```
-
-### security:lockdown
-Manage emergency security lockdown mode
-
-```bash
-php glueful security:lockdown
-```
-
-### security:scan
-Scan for security vulnerabilities
-
-```bash
-php glueful security:scan
-```
-
-### security:vulnerabilities
-Check for known vulnerabilities in dependencies
-
-```bash
-php glueful security:vulnerabilities
-```
-
-## Extensions
-
-### extensions:list
-List discovered extensions with comprehensive status
-
-```bash
-php glueful extensions:list
-```
-
-### extensions:info
-Show detailed extension information
-
-```bash
-php glueful extensions:info <slug>
-php glueful extensions:info Aegis
-```
-
-### extensions:why
-Explain why/how a provider was included or excluded
-
-```bash
-php glueful extensions:why <provider>
-```
-
-### extensions:summary
-Show startup summary and diagnostics
-
-```bash
-php glueful extensions:summary
-```
-
-### extensions:cache
-Build extensions cache for production with verification
-
-```bash
-php glueful extensions:cache
-```
-
-### extensions:clear
-Clear extensions cache with optional development reset
-
-```bash
-php glueful extensions:clear
-```
-
-### extensions:enable
-Enable extension (development only)
-
-```bash
-php glueful extensions:enable <name>
-```
-
-### extensions:disable
-Disable extension (development only)
-
-```bash
-php glueful extensions:disable <name>
-```
-
-## System
-
-### system:check
-Validate framework installation and configuration
-
-```bash
-php glueful system:check
-```
-
-### system:production
-Comprehensive production environment configuration and validation
-
-```bash
-php glueful system:production
+php glueful serve
+php glueful serve --host=0.0.0.0 --port=9000
+php glueful serve --watch
 ```
 
 ## Database
 
-### db:status
-Show database connection status and statistics
-
 ```bash
+php glueful migrate:create CreateUsersTable
+php glueful migrate:run
+php glueful migrate:rollback
+php glueful migrate:status
+
 php glueful db:status
-```
-
-### db:reset
-Reset database to clean state (drops all tables)
-
-```bash
+php glueful db:profile
 php glueful db:reset
+php glueful db:seed
 ```
 
-## Installation
-
-### install
-Run installation setup wizard for new Glueful installation
+## Scaffolding
 
 ```bash
-php glueful install
+php glueful scaffold:controller UserController
+php glueful scaffold:model User
+php glueful scaffold:request CreateUserRequest
+php glueful scaffold:middleware EnsureAdmin
+php glueful scaffold:job SendWelcomeEmail
+php glueful scaffold:test UserControllerTest
+php glueful scaffold:factory UserFactory
+php glueful scaffold:seeder UserSeeder
+php glueful scaffold:resource UserResource
+php glueful scaffold:rule StrongPassword
+php glueful scaffold:filter UserFilter
 ```
 
-## Creating Custom Commands
-
-### Basic Command
-
-```php
-<?php
-
-namespace App\Console\Commands;
-
-use Glueful\Console\BaseCommand;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
-
-class GreetCommand extends BaseCommand
-{
-    protected static $defaultName = 'app:greet';
-    protected static $defaultDescription = 'Greet a user';
-
-    protected function configure(): void
-    {
-        $this->addArgument('name', InputArgument::REQUIRED, 'User name');
-        $this->addOption('yell', 'y', InputOption::VALUE_NONE, 'Yell the greeting');
-    }
-
-    protected function execute($input, $output): int
-    {
-        $name = $input->getArgument('name');
-        $message = "Hello, {$name}!";
-
-        if ($input->getOption('yell')) {
-            $message = strtoupper($message);
-        }
-
-        $this->success($message);
-
-        return self::SUCCESS;
-    }
-}
-```
-
-### Command with Dependencies
-
-```php
-class ProcessUsersCommand extends BaseCommand
-{
-    protected static $defaultName = 'app:process-users';
-
-    public function __construct(
-        private UserRepository $users,
-        private EmailService $email
-    ) {
-        parent::__construct();
-    }
-
-    protected function execute($input, $output): int
-    {
-        $users = $this->users->findActive();
-
-        $this->info("Processing {count($users)} users...");
-
-        $this->progressBar(count($users), function ($bar) use ($users) {
-            foreach ($users as $user) {
-                $this->processUser($user);
-                $bar->advance();
-            }
-        });
-
-        $this->success('All users processed!');
-
-        return self::SUCCESS;
-    }
-}
-```
-
-### Interactive Command
-
-```php
-class SetupCommand extends BaseCommand
-{
-    protected static $defaultName = 'app:setup';
-
-    protected function execute($input, $output): int
-    {
-        $this->info('Welcome to setup!');
-
-        $name = $this->ask('Application name');
-        $email = $this->ask('Admin email', 'admin@example.com');
-        $password = $this->secret('Admin password');
-
-        $env = $this->choice(
-            'Environment',
-            ['development', 'staging', 'production'],
-            'development'
-        );
-
-        if (!$this->confirm('Continue with setup?', true)) {
-            $this->warning('Setup cancelled');
-            return self::FAILURE;
-        }
-
-        // Perform setup...
-
-        $this->success('Setup complete!');
-
-        return self::SUCCESS;
-    }
-}
-```
-
-## Helper Methods
-
-All commands extending `BaseCommand` have access to:
-
-### Output Methods
-- `success(string $message)` - Success message
-- `error(string $message)` - Error message
-- `warning(string $message)` - Warning message
-- `info(string $message)` - Info message
-- `note(string $message)` - Note
-- `tip(string $message)` - Tip
-
-### Interactive Methods
-- `ask(string $question, $default = null)` - Ask question
-- `secret(string $question)` - Ask for password/secret
-- `confirm(string $question, bool $default = false)` - Yes/no confirmation
-- `choice(string $question, array $choices, $default = null)` - Select from choices
-
-### Display Methods
-- `table(array $headers, array $rows)` - Display table
-- `progressBar(int $steps, callable $callback)` - Show progress bar
-
-### Safety Methods
-- `confirmProduction(string $action)` - Confirm in production
-
-## Exit Codes
-
-- `self::SUCCESS` (0) - Command succeeded
-- `self::FAILURE` (1) - Command failed
-- `self::INVALID` (2) - Invalid usage
-
-## Best Practices
-
-### 1. Use Descriptive Names
+## Cache
 
 ```bash
-# ✅ Good
+php glueful cache:get some:key
+php glueful cache:set some:key "value" --ttl=3600
+php glueful cache:delete some:key
+php glueful cache:expire some:key 120
+php glueful cache:ttl some:key
+php glueful cache:inspect some:key
+php glueful cache:status
 php glueful cache:clear
+php glueful cache:purge
+php glueful cache:maintenance
+```
+
+## Queue
+
+```bash
 php glueful queue:work
-
-# ❌ Bad
-php glueful cc
-php glueful qw
+php glueful queue:autoscale
+php glueful queue:scheduler
 ```
 
-### 2. Handle Errors Gracefully
+## OpenAPI / Docs
 
-```php
-protected function execute($input, $output): int
-{
-    try {
-        $this->processData();
-        $this->success('Processing complete');
-        return self::SUCCESS;
-    } catch (\Exception $e) {
-        $this->error($e->getMessage());
-        return self::FAILURE;
-    }
-}
+```bash
+php glueful generate:openapi
 ```
 
-### 3. Provide Feedback
+## Routing / Container
 
-```php
-$this->info('Starting process...');
-// Do work
-$this->success('Process complete!');
+```bash
+php glueful route:debug
+php glueful route:cache:status
+php glueful route:cache:clear
+
+php glueful di:container:debug
+php glueful di:container:validate
+php glueful di:container:compile
+php glueful di:container:map
+php glueful di:lazy:status
 ```
 
-### 4. Use Progress Bars
+## Extensions
 
-```php
-$this->progressBar(count($items), function ($bar) use ($items) {
-    foreach ($items as $item) {
-        $this->process($item);
-        $bar->advance();
-    }
-});
+```bash
+php glueful create:extension Billing
+php glueful extensions:list
+php glueful extensions:info billing
+php glueful extensions:enable billing
+php glueful extensions:disable billing
+php glueful extensions:cache
+php glueful extensions:clear
+php glueful extensions:summary
+php glueful extensions:why Some\\Provider\\Class
+php glueful extensions:diagnose
 ```
 
-## Next Steps
+## Security / Auth
 
-- [Creating Commands](/cookbook/console-commands) - Detailed guide
-- [Queue Workers](/features/queues-jobs) - Background jobs
-- [Task Scheduler](/features/scheduling) - Scheduled tasks
+```bash
+php glueful security:check
+php glueful security:scan
+php glueful security:report
+php glueful security:vulnerabilities
+php glueful security:lockdown
+php glueful security:reset-password
+php glueful security:revoke-tokens
+```
+
+## Other Useful Commands
+
+```bash
+php glueful webhook:list
+php glueful webhook:test
+php glueful webhook:retry
+
+php glueful api:version:list
+php glueful api:version:deprecate
+
+php glueful notifications:process-retries
+php glueful archive:manage
+php glueful test:watch
+php glueful version
+```
+
+## Notes
+
+- Older command names such as `generate:controller`, `generate:api-definitions`, and `generate:api-docs` should not be used unless they exist in your installed version.
+- For most new app code generation, prefer the `scaffold:*` commands.

--- a/content/extensions.md
+++ b/content/extensions.md
@@ -1,0 +1,211 @@
+---
+title: Extensions
+description: Official Glueful extensions for RBAC, SSO, email, push, search, payments, and runtime integrations.
+---
+
+::u-page-section
+
+#title
+<span class="text-3xl sm:text-4xl lg:text-5xl text-pretty tracking-tight font-bold text-highlighted">
+  Extend <span class="text-raspberry-600">Glueful</span> without bloating the core
+</span>
+
+#description
+<div class="text-lg text-gray-600 dark:text-gray-300 max-w-3xl">
+  Glueful keeps the framework lean and lets you add product-specific capabilities through extensions. Official packages are published as Composer packages of type <code>glueful-extension</code> and can also be developed locally from the <code>extensions/</code> directory in your app.
+</div>
+
+#features
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">Composer-Native</span>
+
+  #description
+  <div>Install extensions with Composer, rebuild the extension cache, and keep your application modular as requirements grow.</div>
+
+  :::
+
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">Auto-Discoverable</span>
+
+  #description
+  <div>Glueful can discover extension packages and load their providers, routes, migrations, commands, and configuration through the extension system.</div>
+
+  :::
+
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">Local Development Friendly</span>
+
+  #description
+  <div>Develop and test local extensions from the repository or app-level <code>extensions/</code> directory before publishing packages.</div>
+
+  :::
+::
+
+::u-page-section{class="bg-gradient-to-b from-gray-50/50 to-white dark:from-gray-900/50 dark:to-gray-950"}
+
+#title
+<span class="text-3xl sm:text-4xl lg:text-5xl text-pretty tracking-tight font-bold text-highlighted">
+  Official packages
+</span>
+
+#description
+<div class="text-lg text-gray-600 dark:text-gray-300 max-w-3xl">
+  These packages are part of the current Glueful ecosystem and cover common product needs that many API teams want to add without building them from scratch.
+</div>
+
+<div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+  <div class="rounded-2xl border border-raspberry-100/80 bg-white/90 p-6 shadow-sm ring-1 ring-black/5 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5 dark:ring-white/10">
+    <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-raspberry-50 text-raspberry-600 dark:bg-raspberry-500/10">
+      <span class="i-lucide-box h-6 w-6 block"></span>
+    </div>
+    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Aegis</h3>
+    <p class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">Role-based access control for Glueful with roles, permissions, and authorization workflows without building your own RBAC layer.</p>
+    <div class="mt-4 flex flex-wrap gap-2 text-xs">
+      <span class="rounded-full bg-raspberry-50 px-3 py-1 text-raspberry-700 dark:bg-raspberry-500/10 dark:text-raspberry-300">RBAC</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Permissions</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Access Control</span>
+    </div>
+    <a class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-azure-radiance-600 hover:text-azure-radiance-700" href="https://packagist.org/packages/glueful/aegis" target="_blank" rel="noopener">glueful/aegis</a>
+  </div>
+
+  <div class="rounded-2xl border border-azure-radiance-100/80 bg-white/90 p-6 shadow-sm ring-1 ring-black/5 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5 dark:ring-white/10">
+    <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-azure-radiance-50 text-azure-radiance-600 dark:bg-azure-radiance-500/10">
+      <span class="i-lucide-box h-6 w-6 block"></span>
+    </div>
+    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Entrada</h3>
+    <p class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">Social login and SSO integration for OAuth and OpenID Connect flows when your API needs identity federation and external providers.</p>
+    <div class="mt-4 flex flex-wrap gap-2 text-xs">
+      <span class="rounded-full bg-azure-radiance-50 px-3 py-1 text-azure-radiance-700 dark:bg-azure-radiance-500/10 dark:text-azure-radiance-300">OAuth</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">OIDC</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">SSO</span>
+    </div>
+    <a class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-azure-radiance-600 hover:text-azure-radiance-700" href="https://packagist.org/packages/glueful/entrada" target="_blank" rel="noopener">glueful/entrada</a>
+  </div>
+
+  <div class="rounded-2xl border border-amber-100/80 bg-white/90 p-6 shadow-sm ring-1 ring-black/5 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5 dark:ring-white/10">
+    <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-amber-50 text-amber-600 dark:bg-amber-500/10">
+      <span class="i-lucide-box h-6 w-6 block"></span>
+    </div>
+    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Email Notification</h3>
+    <p class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">Email delivery capabilities built on Symfony Mailer for transactional notifications, account flows, and outbound messaging.</p>
+    <div class="mt-4 flex flex-wrap gap-2 text-xs">
+      <span class="rounded-full bg-amber-50 px-3 py-1 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300">Email</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Mailer</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Notifications</span>
+    </div>
+    <a class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-azure-radiance-600 hover:text-azure-radiance-700" href="https://packagist.org/packages/glueful/email-notification" target="_blank" rel="noopener">glueful/email-notification</a>
+  </div>
+
+  <div class="rounded-2xl border border-violet-100/80 bg-white/90 p-6 shadow-sm ring-1 ring-black/5 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5 dark:ring-white/10">
+    <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-violet-50 text-violet-600 dark:bg-violet-500/10">
+      <span class="i-lucide-box h-6 w-6 block"></span>
+    </div>
+    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Notiva</h3>
+    <p class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">Push notifications for FCM, APNs, and Web Push when your platform needs multi-device delivery beyond email.</p>
+    <div class="mt-4 flex flex-wrap gap-2 text-xs">
+      <span class="rounded-full bg-violet-50 px-3 py-1 text-violet-700 dark:bg-violet-500/10 dark:text-violet-300">FCM</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">APNs</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Web Push</span>
+    </div>
+    <a class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-azure-radiance-600 hover:text-azure-radiance-700" href="https://packagist.org/packages/glueful/notiva" target="_blank" rel="noopener">glueful/notiva</a>
+  </div>
+
+  <div class="rounded-2xl border border-emerald-100/80 bg-white/90 p-6 shadow-sm ring-1 ring-black/5 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5 dark:ring-white/10">
+    <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10">
+      <span class="i-lucide-box h-6 w-6 block"></span>
+    </div>
+    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Meilisearch</h3>
+    <p class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">Full-text search integration for applications that need fast external indexing, search endpoints, and richer query experiences.</p>
+    <div class="mt-4 flex flex-wrap gap-2 text-xs">
+      <span class="rounded-full bg-emerald-50 px-3 py-1 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300">Search</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Indexing</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Meilisearch</span>
+    </div>
+    <a class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-azure-radiance-600 hover:text-azure-radiance-700" href="https://packagist.org/packages/glueful/meilisearch" target="_blank" rel="noopener">glueful/meilisearch</a>
+  </div>
+
+  <div class="rounded-2xl border border-teal-100/80 bg-white/90 p-6 shadow-sm ring-1 ring-black/5 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5 dark:ring-white/10">
+    <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-teal-50 text-teal-600 dark:bg-teal-500/10">
+      <span class="i-lucide-box h-6 w-6 block"></span>
+    </div>
+    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Payvia</h3>
+    <p class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">Unified payment gateway bridge for Stripe, Paystack, Flutterwave, and other payment flows so billing logic is easier to standardize.</p>
+    <div class="mt-4 flex flex-wrap gap-2 text-xs">
+      <span class="rounded-full bg-teal-50 px-3 py-1 text-teal-700 dark:bg-teal-500/10 dark:text-teal-300">Payments</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Gateways</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Billing</span>
+    </div>
+    <a class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-azure-radiance-600 hover:text-azure-radiance-700" href="https://packagist.org/packages/glueful/payvia" target="_blank" rel="noopener">glueful/payvia</a>
+  </div>
+
+  <div class="rounded-2xl border border-sky-100/80 bg-white/90 p-6 shadow-sm ring-1 ring-black/5 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5 dark:ring-white/10">
+    <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-sky-50 text-sky-600 dark:bg-sky-500/10">
+      <span class="i-lucide-box h-6 w-6 block"></span>
+    </div>
+    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Runiva</h3>
+    <p class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">Server runtime integration for RoadRunner, Swoole, and FrankenPHP for teams running long-lived PHP application processes.</p>
+    <div class="mt-4 flex flex-wrap gap-2 text-xs">
+      <span class="rounded-full bg-sky-50 px-3 py-1 text-sky-700 dark:bg-sky-500/10 dark:text-sky-300">RoadRunner</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">Swoole</span>
+      <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-white/10 dark:text-gray-300">FrankenPHP</span>
+    </div>
+    <a class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-azure-radiance-600 hover:text-azure-radiance-700" href="https://packagist.org/packages/glueful/runiva" target="_blank" rel="noopener">glueful/runiva</a>
+  </div>
+</div>
+::
+
+::u-page-section
+
+#title
+<span class="text-3xl sm:text-4xl lg:text-5xl text-pretty tracking-tight font-bold text-highlighted">
+  Local and custom extensions
+</span>
+
+#description
+<div class="text-lg text-gray-600 dark:text-gray-300 max-w-3xl">
+  The local repository also includes extension packages used for active Glueful development and integration work.
+</div>
+
+#features
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">Build Your Own</span>
+
+  #description
+  <div>Glueful’s extension system supports local packages with providers, routes, config, migrations, and commands. See the extension cookbook page for creation and packaging details.</div>
+
+  :::
+::
+
+::u-page-section
+
+## Install an extension
+
+```bash
+composer require glueful/aegis
+php glueful extensions:cache
+php glueful extensions:list
+```
+
+For local development or explicit enable/disable flows, you can also use:
+
+```bash
+php glueful extensions:enable Aegis
+php glueful extensions:disable Aegis
+php glueful extensions:info Aegis
+php glueful extensions:summary
+```
+
+## Related docs
+
+- [Cookbook: Extensions](/cookbook/extensions)
+- [Getting Started](/getting-started)
+- [CLI Reference](/cli-reference)
+::

--- a/content/index.md
+++ b/content/index.md
@@ -1,7 +1,7 @@
 ---
 seo:
-  title: Glueful — Modern API Framework
-  description: Build secure, high‑throughput PHP APIs with first‑class DX, JWT auth, OpenAPI generation, rate limiting, and RBAC.
+  title: Glueful — Build Production PHP APIs Faster
+  description: Start from the Glueful API skeleton and ship secure, documented PHP APIs with explicit routing, DI, auth, queues, storage, and operational tooling.
 ---
 ::u-page-hero{orientation = "horizontal" class="home-page-hero"}
 
@@ -13,28 +13,28 @@ seo:
 <span class="font-bold text-raspberry-600">Glueful</span>
 
 #title
-<span class="font-light text-gray-900 dark:text-white text-5xl lg:text-6xl">The <span class="font-semibold text-raspberry-600">Modern</span></span><br><span class="font-bold text-raspberry-600 text-5xl lg:text-6xl">API Framework</span>
+<span class="font-light text-gray-900 dark:text-white text-5xl lg:text-6xl">Build <span class="font-semibold text-raspberry-600">production PHP APIs</span></span><br><span class="font-bold text-raspberry-600 text-5xl lg:text-6xl">without starting from zero</span>
 
 #description
 
 <p class="text-xl text-gray-600 dark:text-gray-300 leading-relaxed max-w-3xl">
-  Build modern, secure APIs with <strong class="text-azure-radiance-600">speed</strong> and <strong class="text-raspberry-600">quality developer experience</strong>. Glueful brings modern tooling and enterprise‑grade security to PHP 8.3+.
+  Start with <strong class="text-azure-radiance-600">glueful/api-skeleton</strong>, then grow into a full API platform with explicit routing, context-aware DI, authentication flows, queues, notifications, storage, OpenAPI generation, and operational CLI tooling.
 </p>
 
-  <div class="flex flex-wrap items-center justify-center gap-6 mt-8 text-sm text-gray-600 dark:text-gray-400">
-    <div class="flex items-center gap-2">
-      <div class="w-2 h-2 bg-green-500 rounded-full"></div>
-      <span>Open Source</span>
-    </div>
-    <div class="flex items-center gap-2">
-      <div class="w-2 h-2 bg-blue-500 rounded-full"></div>
-      <span>JWT Authentication</span>
-    </div>
-    <div class="flex items-center gap-2">
-      <div class="w-2 h-2 bg-orange-500 rounded-full"></div>
-      <span>High‑Throughput Routing</span>
-    </div>
+<div class="flex flex-wrap items-center justify-center gap-6 mt-8 text-sm text-gray-600 dark:text-gray-400">
+  <div class="flex items-center gap-2">
+    <div class="w-2 h-2 bg-green-500 rounded-full"></div>
+    <span>API Skeleton First</span>
   </div>
+  <div class="flex items-center gap-2">
+    <div class="w-2 h-2 bg-blue-500 rounded-full"></div>
+    <span>Explicit Routes + DI</span>
+  </div>
+  <div class="flex items-center gap-2">
+    <div class="w-2 h-2 bg-orange-500 rounded-full"></div>
+    <span>Built For Real Deployments</span>
+  </div>
+</div>
 
 #links
   :::u-button{class="bg-azure-radiance-500 hover:bg-azure-radiance-600 text-white hover:shadow-azure-radiance-500/25 transform hover:scale-105 transition-all duration-300 hover:animate-none"}
@@ -43,7 +43,7 @@ seo:
   to: /getting-started
   trailing-icon: i-lucide-rocket
   ---
-  Start Building
+  Start With The Skeleton
   :::
 
   :::u-button{class="hover:shadow-primary-500/25 transform hover:scale-105 transition-all duration-300 hover:animate-none"}
@@ -57,13 +57,25 @@ seo:
   ---
   GitHub
   :::
+
+  :::u-button{class="hover:shadow-primary-500/25 transform hover:scale-105 transition-all duration-300 hover:animate-none"}
+  ---
+  color: neutral
+  size: xl
+  to: /extensions
+  variant: outline
+  trailing-icon: i-lucide-box
+  ---
+  Browse Extensions
+  :::
 #default
   :::prose-pre{code = "composer create-project glueful/api-skeleton my-project" filename = "Terminal"}
   ```bash [Terminal]
-  # Create a new Glueful project from the API skeleton (recommended)
   composer create-project glueful/api-skeleton my-project
   cd my-project
-  # Start the development server
+  php glueful install --quiet
+  php glueful scaffold:controller UserController --api
+  php glueful generate:openapi --ui
   php glueful serve
   ```
   :::
@@ -86,31 +98,31 @@ seo:
 #title
 <div class="mt-12 mb-6 scroll-mt-[calc(48px+45px+var(--ui-header-height))] lg:scroll-mt-[calc(48px+var(--ui-header-height))] [&>a]:focus-visible:outline-(--ui-primary) [&>a>code]:border-dashed hover:[&>a>code]:border-(--ui-primary) hover:[&>a>code]:text-(--ui-primary) [&>a>code]:text-xl/7 [&>a>code]:font-bold [&>a>code]:transition-colors text-3xl sm:text-4xl lg:text-5xl text-pretty tracking-tight font-bold text-highlighted text-left @container relative flex">
   <div class="*:leading-9">
-    <p class="my-5 leading-7 text-pretty font-normal text-gray-600 dark:text-gray-300 ">Write <span class="text-azure-radiance-600 font-semibold">Beautiful Code</span></p>
+    <p class="my-5 leading-7 text-pretty font-normal text-gray-600 dark:text-gray-300 ">A faster path from idea to deployed API</p>
   </div>
-  <div class="hidden @min-[1020px]:block"><img src="/images/light/line-2.svg" alt="Line Decoration" class="absolute top-0 right-0 size-full transform scale-95 translate-x-[70%]" alt="line-2"></div>
+  <div class="hidden @min-[1020px]:block"><img src="/images/light/line-2.svg" alt="Line Decoration" class="absolute top-0 right-0 size-full transform scale-95 translate-x-[70%]"></div>
 </div>
 
 #description
 
-<div class="text-left mb-12 text-gray-600 dark:text-gray-300 max-w-2xl">
-  Elegant, type-safe code that feels like the future. Experience modern development with built‑in validation, dependency injection, and minimal boilerplate.
-  </div>
+<div class="text-left mb-12 text-gray-600 dark:text-gray-300 max-w-3xl">
+  Glueful is opinionated where it helps: start from a working API app, use explicit routes and controllers, rely on context-aware DI instead of hidden globals, and add higher-level features only when your app needs them.
+</div>
 
-  <div class="flex items-center gap-8 mb-8 text-sm text-gray-500 dark:text-gray-400 text-left">
-    <div class="flex items-center gap-2">
-      <div class="w-3 h-3 rounded-full bg-gradient-to-r from-blue-500 to-blue-600"></div>
-      <span>Type Safety</span>
-    </div>
-    <div class="flex items-center gap-2">
-      <div class="w-3 h-3 rounded-full bg-gradient-to-r from-purple-500 to-purple-600"></div>
-      <span>Sensible Defaults</span>
-    </div>
-    <div class="flex items-center gap-2">
-      <div class="w-3 h-3 rounded-full bg-gradient-to-r from-green-500 to-green-600"></div>
-      <span>Auto DI</span>
-    </div>
+<div class="flex items-center gap-8 mb-8 text-sm text-gray-500 dark:text-gray-400 text-left">
+  <div class="flex items-center gap-2">
+    <div class="w-3 h-3 rounded-full bg-gradient-to-r from-blue-500 to-blue-600"></div>
+    <span>PHP 8.3+</span>
   </div>
+  <div class="flex items-center gap-2">
+    <div class="w-3 h-3 rounded-full bg-gradient-to-r from-purple-500 to-purple-600"></div>
+    <span>ApplicationContext + DI</span>
+  </div>
+  <div class="flex items-center gap-2">
+    <div class="w-3 h-3 rounded-full bg-gradient-to-r from-green-500 to-green-600"></div>
+    <span>OpenAPI + CLI Tooling</span>
+  </div>
+</div>
 
 :::clean-code-showcase
 :::
@@ -125,31 +137,31 @@ seo:
 #title
 <div class="text-3xl sm:text-4xl lg:text-5xl text-pretty tracking-tight font-bold text-highlighted text-left @container relative flex">
   <div class="*:leading-9">
-    <p class="my-5 leading-7 text-pretty font-normal text-gray-600 dark:text-gray-300">Why developers choose <span class="text-azure-radiance-500 font-semibold">Glueful</span></p>
+    <p class="my-5 leading-7 text-pretty font-normal text-gray-600 dark:text-gray-300">Why developers adopt <span class="text-azure-radiance-500 font-semibold">Glueful</span></p>
   </div>
   <div class="hidden @min-[1020px]:block">
-    <img  class="absolute top-0 right-0 size-full transform scale-95 translate-x-[70%]" src="/images/light/line-2.svg" alt="Line Decoration"/>
+    <img class="absolute top-0 right-0 size-full transform scale-95 translate-x-[70%]" src="/images/light/line-2.svg" alt="Line Decoration"/>
   </div>
 </div>
 
 #description
 
 <div class="text-lg text-gray-600 dark:text-gray-300 text-left max-w-3xl">
-  <p>Built by developers, for developers. Every feature is designed to eliminate friction and accelerate your API development workflow.</p>
+  <p>Glueful is strongest when you want a pragmatic API framework that starts lean but already includes the hard parts teams usually stitch together later.</p>
 </div>
 
 <div class="flex items-center gap-8 mb-12 text-sm text-gray-500 dark:text-gray-400">
   <div class="flex items-center gap-2">
-    <span class="text-2xl font-bold text-azure-radiance-600">Faster</span>
-    <span>Developer Velocity</span>
+    <span class="text-2xl font-bold text-azure-radiance-600">Fast</span>
+    <span>Onboarding</span>
   </div>
   <div class="flex items-center gap-2">
-    <span class="text-2xl font-bold text-azure-radiance-600">Proactive</span>
-    <span>Security Tooling</span>
+    <span class="text-2xl font-bold text-azure-radiance-600">Explicit</span>
+    <span>Architecture</span>
   </div>
   <div class="flex items-center gap-2">
-    <span class="text-2xl font-bold text-azure-radiance-600">Strong</span>
-    <span>Type‑Hinted APIs</span>
+    <span class="text-2xl font-bold text-azure-radiance-600">Built-In</span>
+    <span>API Ops</span>
   </div>
 </div>
 
@@ -157,30 +169,40 @@ seo:
   :::u-page-feature
 
   #title
-  <span class="font-bold text-raspberry-600">Modern Architecture</span>
+  <span class="font-bold text-raspberry-600">Start From A Working API App</span>
 
   #description
-  <div>PHP 8.3+ foundation with attributes, typed properties, and constructor promotion. RESTful by default with route annotations and generators that produce OpenAPI specs. Built‑in request/response validation helpers and type‑hinted code throughout.</div>
+  <div>`glueful/api-skeleton` gives you bootstrap, config, starter routes, migrations, SQLite by default, queue configuration, OpenAPI configuration, extension loading, and a real CLI entrypoint on day one.</div>
 
   :::
 
   :::u-page-feature
 
   #title
-  <span class="font-bold text-raspberry-600">Developer Experience</span>
+  <span class="font-bold text-raspberry-600">Stay Explicit As You Scale</span>
 
   #description
-  <div>50+ CLI commands for everyday tasks. Smart migrations, extension management, and built‑in profiling/metrics. From `php glueful serve` to production deployment in minutes.</div>
+  <div>Glueful’s `ApplicationContext`, explicit routing, and container-driven services make the architecture easier to reason about than magic-heavy frameworks that hide request state and service resolution.</div>
 
   :::
 
   :::u-page-feature
 
   #title
-  <span class="font-bold text-raspberry-600">Security</span>
+  <span class="font-bold text-raspberry-600">Ship More Than CRUD</span>
 
   #description
-  <div>JWT authentication with dual‑layer sessions, fine‑grained RBAC, and configurable rate limiting. Built‑in vulnerability scanning, audit trails, and emergency lockdown mode. OWASP‑aligned protections (CSRF, security headers, rate limits).</div>
+  <div>Auth flows, notifications, queues, rate limiting, distributed locks, file uploads, OpenAPI generation, and production checks are already part of the framework story, not an afterthought.</div>
+
+  :::
+
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">Add Official Extensions</span>
+
+  #description
+  <div>Extend the core with official packages for RBAC, social login, email delivery, push notifications, full-text search, payments, and runtime integrations without turning the framework itself into a monolith.</div>
 
   :::
 ::
@@ -188,100 +210,105 @@ seo:
 ::div{class="h-px bg-gradient-to-r from-transparent via-raspberry-400/50 via-purple-400/50 to-transparent dark:via-raspberry-600/50 dark:via-purple-600/50"}
 ::
 
-::u-page-section{class="api-generation-container bg-gradient-to-b from-gray-50/50 to-white dark:from-gray-900/50 dark:to-gray-950"}
+::u-page-section{class="bg-gradient-to-b from-gray-50/50 to-white dark:from-gray-900/50 dark:to-gray-950 py-16"}
 
 #title
-
 <span class="text-3xl sm:text-4xl lg:text-5xl text-pretty tracking-tight font-bold text-highlighted text-center mb-4">
-  <span class="text-gray-900 dark:text-white font-light">From Database to <span class="text-raspberry-600 font-semibold">API in Seconds</span></span>
+  <span class="text-gray-900 dark:text-white font-light">What developers get <span class="text-raspberry-600 font-semibold">immediately</span></span>
 </span>
 
 #description
-
-  <div class="text-center mb-12 text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
-  Generic CRUD endpoints via the built‑in Resource Controller. Configure per‑resource policies and validation to expose tables safely with documentation.
-  </div>
-
-::
-
-::div{class="h-px bg-gradient-to-r from-transparent via-raspberry-400/50 via-purple-400/50 to-transparent dark:via-raspberry-600/50 dark:via-purple-600/50"}
-::
-
-::u-page-section{orientation = "horizontal" class="bg-gradient-to-br from-raspberry-50/50 via-white to-purple-50/50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 py-16"}
-
-#title
-<span class="leading-7 text-pretty font-normal text-gray-600 dark:text-gray-300"><span class="text-raspberry-600 font-semibold">Extensible</span> by design</span>
-
-#description
-
-<div class="space-y-4">
-  <p>Build modular APIs that grow with your needs. Extensions are first-class citizens with full access to Glueful's powerful features.</p>
-  
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
-    <div class="p-4 bg-white/50 dark:bg-gray-800/50 rounded-lg border border-gray-200/50 dark:border-gray-700/50">
-      <div class="text-raspberry-600 dark:text-raspberry-400 font-semibold mb-2">Dynamic Extensions</div>
-      <div class="text-sm text-gray-600 dark:text-gray-400">Enable/disable extensions via CLI, designed for zero‑downtime deploys.</div>
-    </div>
-    <div class="p-4 bg-white/50 dark:bg-gray-800/50 rounded-lg border border-gray-200/50 dark:border-gray-700/50">
-      <div class="text-raspberry-600 dark:text-raspberry-400 font-semibold mb-2">Full DI Support</div>
-      <div class="text-sm text-gray-600 dark:text-gray-400">Automatic service injection, middleware, and event listeners.</div>
-    </div>
-    <div class="p-4 bg-white/50 dark:bg-gray-800/50 rounded-lg border border-gray-200/50 dark:border-gray-700/50">
-      <div class="text-raspberry-600 dark:text-raspberry-400 font-semibold mb-2">Metrics Tracked</div>
-      <div class="text-sm text-gray-600 dark:text-gray-400">Built-in metrics for load time, memory usage, and request handling.</div>
-    </div>
-  </div>
+<div class="text-center mb-12 text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+  Glueful’s starter path is valuable because it shortens the gap between “new project” and “working API with operational basics.”
 </div>
 
-#default
-:::prose-pre{code = "php glueful extensions create MyExtension" filename = "Terminal"}
-::div
-```bash [Terminal]
-# Create a new extension with full scaffolding
-php glueful extensions:create PaymentGateway
+#features
+  :::u-page-feature
 
-✓ Created extension directory: extensions/PaymentGateway/
-✓ Generated controller, service, and routes
-✓ Added service provider and config
-✓ Created README and tests
+  #title
+  <span class="font-bold text-raspberry-600">Scaffolding</span>
 
-# Enable and use immediately
-php glueful extensions:enable PaymentGateway
-✓ Extension enabled successfully
+  #description
+  <div>Generate controllers, models, requests, jobs, rules, tests, factories, seeders, filters, and middleware with the `scaffold:*` commands instead of hand-rolling boilerplate.</div>
 
-# See all available extensions
-php glueful extensions:info
-```
+  :::
 
-::
-:::
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">API Documentation</span>
+
+  #description
+  <div>Use `php glueful generate:openapi --ui` to generate your API spec and a browsable UI without wiring a separate documentation stack together.</div>
+
+  :::
+
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">Operational Defaults</span>
+
+  #description
+  <div>Health checks, security scanning, route diagnostics, queue presets, storage configuration, and deployment-oriented config are present from the start.</div>
+
+  :::
+
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">API Ergonomics</span>
+
+  #description
+  <div>Versioning, field selection, rate limiting, eventing, notifications, and extension hooks make Glueful fit real API teams better than a bare router-and-container setup.</div>
+
+  :::
 ::
 
 ::div{class="h-px bg-gradient-to-r from-transparent via-azure-radiance-400/50 via-purple-400/50 to-transparent dark:via-azure-radiance-600/50 dark:via-purple-600/50"}
 ::
 
-  ::u-page-c-t-a
-  ---
-  links:
-    - label: Get started
-      to: /getting-started
-      trailing-icon: i-lucide-rocket
-      color: neutral
-      size: xl
-      class: "bg-azure-radiance-600 hover:bg-azure-radiance-700 text-white hover:shadow-azure-radiance-500/25 transform hover:scale-105 transition-all duration-300 hover:animate-none"
-    - label: 'Github'
-      to: https://github.com/glueful
-      icon: i-tabler-brand-github-filled
-      target: _blank
-      color: neutral
-      size: xl
-      class: "hover:shadow-primary-500/25 transform hover:scale-105 transition-all duration-300 hover:animate-none"
-      variant: solid
-  description: Ready to transform your API development? Join thousands of developers who've already made the switch to Glueful. From rapid prototyping to enterprise production, we've got you covered. Get production-ready APIs in minutes, not months.
-  variant: ghost
-  ---
+::u-page-section{class="api-generation-container bg-gradient-to-b from-white to-azure-radiance-50/40 dark:from-gray-950 dark:to-gray-900"}
+
+#title
+
+<span class="text-3xl sm:text-4xl lg:text-5xl text-pretty tracking-tight font-bold text-highlighted text-center mb-4">
+  <span class="text-gray-900 dark:text-white font-light">From starter app to <span class="text-raspberry-600 font-semibold">production API platform</span></span>
+</span>
+
+#description
+
+<div class="text-center mb-12 text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+  Start with routes and controllers in the skeleton. Then add database-backed resources, auth and sessions, queues and notifications, storage, extensions, and generated OpenAPI docs as the application grows.
+</div>
+
+#features
+  :::u-page-feature
 
   #title
-  <span class="leading-7 text-pretty font-normal text-left">Build Better <span class="text-azure-radiance-600 font-semibold">APIs</span> <span class="text-azure-radiance-600 font-semibold">Faster</span></span>
+  <span class="font-bold text-raspberry-600">Good Fit For</span>
 
-  ::
+  #description
+  <div>Internal APIs, SaaS backends, webhook-heavy services, queue-driven workloads, and teams that want explicit PHP architecture without rebuilding the same API infrastructure on every project.</div>
+
+  :::
+
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">Extension Ecosystem</span>
+
+  #description
+  <div>Start with the lean framework, then add Aegis, Entrada, Payvia, Meilisearch, Notiva, email-notification, and other Glueful extensions as your product needs grow.</div>
+
+  :::
+
+  :::u-page-feature
+
+  #title
+  <span class="font-bold text-raspberry-600">Next Step</span>
+
+  #description
+  <div>Start with the install path, build your first endpoint, then move into routing, validation, auth, queues, and deployment with the docs path that matches the framework’s current API surface.</div>
+
+  :::
+::

--- a/content/releases.md
+++ b/content/releases.md
@@ -3359,7 +3359,7 @@ use Glueful\Http\Client;
 use Glueful\Http\Builders\ApiClientBuilder;
 
 // Configure retries with custom settings via DI + scoped client
-$client = app(Client::class)
+$client = app($context, Client::class)
     ->createScopedClient(['base_uri' => 'https://api.example.com'])
     ->withRetry([
         'max_retries' => 3,
@@ -3369,7 +3369,7 @@ $client = app(Client::class)
     ]);
 
 // Or use builder with presets
-$apiClient = (new ApiClientBuilder(app(Client::class)))
+$apiClient = (new ApiClientBuilder(app($context, Client::class)))
     ->baseUri('https://payment-gateway.com')
     ->forPayments()
     ->buildWithRetries();
@@ -3477,7 +3477,7 @@ $container->set('cron.cache', CacheMaintenance::class);
 use Glueful\Queue\Jobs\CacheMaintenanceJob;
 use Glueful\Queue\QueueManager;
 
-$queue = app(QueueManager::class);
+$queue = app($context, QueueManager::class);
 $queue->push(CacheMaintenanceJob::class, ['operation' => 'clearExpiredKeys'], 'maintenance');
 ```
 
@@ -3492,7 +3492,7 @@ $cronJob->execute();
 **After:**
 ```php
 /** @var CacheMaintenanceTask $task */
-$task = app(CacheMaintenanceTask::class);
+$task = app($context, CacheMaintenanceTask::class);
 $task->handle(['driver' => 'redis', 'operation' => 'clearExpiredKeys']);
 ```
 
@@ -3627,7 +3627,7 @@ final class PaymentProvider extends BaseServiceProvider
         return [
             // FactoryDefinition gives you full control
             'payment.client' => new FactoryDefinition('payment.client', function(\Psr\Container\ContainerInterface $c) {
-                return new PaymentClient($c->get('http.client'), baseUrl: config('payments.base_url'));
+                return new PaymentClient($c->get('http.client'), baseUrl: config($context, 'payments.base_url'));
             }),
             // Simple autowire helper (shared by default)
             PaymentService::class => $this->autowire(PaymentService::class),
@@ -3665,7 +3665,7 @@ php glueful security:vulnerabilities
 use Glueful\Uploader\FileUploader;
 
 // Upload using the framework uploader (validates and stores metadata)
-$uploader = app(FileUploader::class);
+$uploader = app($context, FileUploader::class);
 $result = $uploader->handleUpload(
     $token,                   // your upload token / CSRF guard
     ['user_id' => $userId, 'key' => 'document'],
@@ -3674,7 +3674,7 @@ $result = $uploader->handleUpload(
 
 // $result contains: ['uuid' => '...', 'url' => 'https://...']
 // To create a presigned link for a known path on S3:
-// $signedUrl = app(Glueful\Uploader\Storage\FlysystemStorage::class)
+// $signedUrl = app($context, Glueful\Uploader\Storage\FlysystemStorage::class)
 //     ->getSignedUrl('documents/example.pdf', 3600);
 ```
 
@@ -3763,13 +3763,13 @@ class UserCreated extends BaseEvent
 }
 
 // Register listener via ListenerProvider
-$provider = app(ListenerProvider::class);
+$provider = app($context, ListenerProvider::class);
 $provider->addListener(UserCreated::class, function (UserCreated $event) {
     // Handle event
 });
 
 // Dispatch via PSR-14 dispatcher
-$dispatcher = app(EventDispatcherInterface::class);
+$dispatcher = app($context, EventDispatcherInterface::class);
 $dispatcher->dispatch(new UserCreated($user));
 ```
 
@@ -3988,7 +3988,7 @@ Notification system wiring improvements with a shared DI provider and a safer em
 
 ::u-alert{color="warning" variant="subtle" icon="i-tabler-alert-triangle"}
 #description
-If you referenced `config('extensions.EmailNotification.retry')`, update to `config('email-notification.retry')`. No breaking API changes are introduced in 1.5.0.
+If you referenced `config($context, 'extensions.EmailNotification.retry')`, update to `config($context, 'email-notification.retry')`. No breaking API changes are introduced in 1.5.0.
 ::
 
 ---

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -120,6 +120,13 @@ export default defineNuxtConfig({
         ]
       },
       {
+        title: 'Extensions',
+        contentCollection: 'docs',
+        contentFilters: [
+          { field: 'path', operator: 'LIKE', value: '/extensions%' }
+        ]
+      },
+      {
         title: 'API Reference',
         contentCollection: 'docs',
         contentFilters: [


### PR DESCRIPTION
Revise and streamline the documentation to align with the glueful/api-skeleton starter app. Major changes: simplified Installation, Quickstart and Build Your First API guides to use composer create-project and starter endpoints (welcome, v1/status, health); replaced platform-specific install steps with concise requirements and CLI commands; updated route and controller examples to use Response helpers and BaseController patterns; clarified routing, middleware and attribute usage; refreshed authentication examples to use controller helpers; added content/extensions.md and updated nuxt.config.ts. These edits harmonize examples, reduce duplication, and make the docs directly copyable from the API skeleton.