### PR TITLE
docs: update extension docs for the re-architecture (framework 1.47.0 Hadar)

### DIFF
--- a/content/6.cookbook/22.console-commands.md
+++ b/content/6.cookbook/22.console-commands.md
@@ -365,17 +365,17 @@ php glueful extensions:debug
 ### Extension Listing and Analysis
 
 ```bash
-# List all extensions with detailed information
+# List all extensions with state (enabled ✓ / available ○ / enabled-but-missing ⚠)
 php glueful extensions:list
 
 # Show extension summary statistics
 php glueful extensions:summary
 
-# Show dependency information for an extension
-php glueful extensions:why MyExtension
+# Detail for one extension (package name, provider FQCN, or slug)
+php glueful extensions:info MyExtension
 
-# Show which extensions depend on a specific extension
-php glueful extensions:why MyExtension --reverse
+# Diagnose discovery + resolver errors and load order
+php glueful extensions:diagnose
 ```
 
 ### Extension Cache Management

--- a/content/6.cookbook/24.extensions.md
+++ b/content/6.cookbook/24.extensions.md
@@ -28,14 +28,14 @@ The Glueful Extensions System provides a modern architecture for extending the f
 ### 1. Check System Status
 
 ```bash
-# List all extensions with status (shows enabled/disabled)
+# List every discovered extension with its state (enabled ✓ / available ○ / enabled-but-missing ⚠)
 php glueful extensions:list
 
-# Show detailed extension information
+# Show detailed extension information (by package name, provider FQCN, or slug)
 php glueful extensions:info blog
 
-# Explain why a provider was included or excluded
-php glueful extensions:why BlogProvider
+# Diagnose discovery + resolver errors (and, in production, whether the cache is present)
+php glueful extensions:diagnose
 
 # Show system summary with performance metrics
 php glueful extensions:summary
@@ -54,13 +54,19 @@ php glueful create:extension my-extension
 ### 3. Install a Composer Extension
 
 ```bash
-# Install via Composer (recommended)
+# 1. Install via Composer
 composer require vendor/my-extension
 
-# Extension will be auto-discovered if type is "glueful-extension"
-# Rebuild cache after adding new packages
+# 2. Enable it — installing does NOT auto-load an extension; it must be added to
+#    config/extensions.php's `enabled` allow-list. This command does that for you
+#    (and recompiles the cache). Accepts the package name, provider FQCN, or slug.
+php glueful extensions:enable my-extension
+
+# 3. In production, (re)build the compiled manifest as part of your deploy step
 php glueful extensions:cache
 ```
+
+> **Installed ≠ enabled.** A `glueful-extension` package is *discovered* by Composer but does nothing until its provider FQCN is in `config/extensions.php` → `enabled`. Use `extensions:enable` (or edit the list by hand). Run `extensions:list` to see which installed extensions are enabled (`✓`) vs available (`○`).
 
 ## Architecture
 
@@ -199,12 +205,18 @@ class MyExtensionServiceProvider extends ServiceProvider
 
 ### CLI Metadata and Slugs
 
-Glueful’s CLI uses a small metadata registry to show friendly names, slugs, versions, and descriptions for your extension. Registering metadata is what enables commands like `extensions:info <slug>` to work with a human‑readable slug instead of the full provider class.
+CLI commands (`extensions:info|enable|disable`) resolve an extension by its **Composer
+package name** (`vendor/my-extension`), its **provider FQCN**, or its **slug** — the last
+path segment of the package name (`my-extension`), matched case-insensitively. This comes
+from Composer discovery and needs no metadata registration.
+
+The optional metadata registry is purely for **display**: a friendly name and description
+shown by `extensions:info`/`list`. (The version column comes from the installed Composer
+package version, falling back to registered metadata.)
 
 - Why register metadata
-  - `extensions:info <slug>` resolves by slug when metadata is present; otherwise you must pass the full provider FQCN.
-  - `extensions:list` can display name/version sourced from metadata instead of just the provider class.
-  - Docs tooling (e.g., comments generator) may also use the registered slug when rendering extension names.
+  - `extensions:info` shows your `name`/`description` instead of just the provider class.
+  - It's optional — resolution and the version column work without it.
 
 - How to register
   - Call `ExtensionManager::registerMeta(self::class, [...])` from your ServiceProvider’s `boot()`:
@@ -273,151 +285,110 @@ class MyServiceProvider extends ServiceProvider implements DeferrableProvider
 
 ## Configuration
 
+Discovery is **Composer-only**, and `config/extensions.php` is a **single `enabled`
+allow-list**: an installed `glueful-extension` package does nothing until its provider
+FQCN appears here. There is no `only` / `dev_only` / `disabled` / `local_path` /
+`scan_composer` — the `enabled` list *is* the allow-list (empty = nothing loads).
+
 ### config/extensions.php
 
 ```php
+<?php
+
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Enabled Extensions
-    |--------------------------------------------------------------------------
-    |
-    | List of extension service providers to load. Discovery order:
-    | 1) enabled, 2) dev_only (non-prod), 3) local dev, 4) composer.
-    |
-    */
     'enabled' => [
-        // Core extensions
-        Glueful\Blog\BlogServiceProvider::class,
-        Glueful\Shop\ShopServiceProvider::class,
-        
-        // Third-party
-        Vendor\Analytics\AnalyticsServiceProvider::class,
+        // Plain string FQCNs (no ::class) so `extensions:enable|disable` can edit
+        // this list safely. Order is preserved; dependencies are reordered for you.
+        'Glueful\\Blog\\BlogServiceProvider',
+        'Vendor\\Analytics\\AnalyticsServiceProvider',
     ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Development Extensions
-    |--------------------------------------------------------------------------
-    |
-    | Extensions only loaded in non-production environments.
-    |
-    */
-    'dev_only' => [
-        Glueful\Debug\DebugServiceProvider::class,
-        Glueful\Profiler\ProfilerServiceProvider::class,
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Disabled Extensions (Blacklist)
-    |--------------------------------------------------------------------------
-    |
-    | Block specific extensions even if discovered. Useful for temporarily
-    | disabling problematic extensions or blocking transitive dependencies.
-    |
-    */
-    'disabled' => [
-        // Example: Block debug tools in production
-        // Barryvdh\Debugbar\ServiceProvider::class,
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Exclusive Allow-List Mode (Ultra-Secure)
-    |--------------------------------------------------------------------------
-    |
-    | When 'only' is set, ONLY these providers load. Nothing else.
-    | This overrides all other discovery methods for maximum security.
-    |
-    */
-    // 'only' => [
-    //     'App\\Core\\CoreProvider',
-    //     'Vendor\\Approved\\ApprovedProvider',
-    // ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Local Extensions Path
-    |--------------------------------------------------------------------------
-    |
-    | Path to scan for local extensions during development.
-    | Set to null to disable local extension scanning.
-    |
-    */
-    'local_path' => env('APP_ENV') === 'production' ? null : 'extensions',
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Composer Package Scanning
-    |--------------------------------------------------------------------------
-    |
-    | Whether to scan Composer packages for glueful-extension types.
-    | Set to false to disable Composer scanning (for troubleshooting).
-    |
-    */
-    'scan_composer' => true,
 ];
 ```
+
+Notes:
+
+- **String FQCNs, not `::class`.** The CLI edits this file as text, so entries must be
+  plain strings. (A stray `Foo::class` literal simply won't match — it'll show as
+  `enabled-but-missing` in `extensions:list`.)
+- **Dev-only extensions:** require them as Composer **dev dependencies** (`require-dev`)
+  so they're absent in production, and list them in `enabled`. Resolution is
+  environment-independent — there's no separate `dev_only` key.
+- **Disabling:** remove the entry from `enabled` (or run `extensions:disable`). There's
+  no blacklist.
+- **App's own providers** (e.g. `AppServiceProvider`) live in `config/serviceproviders.php`
+  under the same single `enabled` key; they're always loaded and are not gated by
+  `extensions.enabled`.
+
+### Declaring requirements (extension authors)
+
+```json
+{
+    "type": "glueful-extension",
+    "extra": {
+        "glueful": {
+            "provider": "Vendor\\MyExtension\\MyExtensionServiceProvider",
+            "requires": {
+                "glueful": ">=1.46.0",
+                "extensions": ["Vendor\\Base\\BaseServiceProvider"]
+            }
+        }
+    }
+}
+```
+
+- `requires.glueful` is a Composer version constraint (matched with `composer/semver`);
+  a mismatch is a resolver error and the extension won't load.
+- `requires.extensions` lists provider FQCNs that must **also be enabled** — they are not
+  auto-enabled; enabling an extension whose dependency isn't enabled is refused.
 
 ## Command Reference
 
 ### Discovery & Information
 
 ```bash
-php glueful extensions:list              # List all discovered extensions with status
-php glueful extensions:info <slug>       # Show detailed extension information
-php glueful extensions:why <provider>    # Explain why a provider was included/excluded
-php glueful extensions:summary           # Show system summary with performance metrics
+php glueful extensions:list              # Every discovered extension + state (✓ / ○ / ⚠); folds in the old `why`
+php glueful extensions:info <name>       # Detail by package name, provider FQCN, or slug (e.g. `blog`)
+php glueful extensions:diagnose          # Resolver errors, load order, and (prod) cache presence
+php glueful extensions:summary           # System summary with performance metrics
 ```
 
 ### Cache Management
 
 ```bash
-php glueful extensions:cache             # Build extensions cache for production
-php glueful extensions:clear             # Clear extensions cache
+php glueful extensions:cache             # Strict: compile the manifest; fails on any resolver error
+php glueful extensions:clear             # Clear the compiled cache
 ```
 
 ### Development Tools
 
 ```bash
-php glueful create:extension <name>      # Create new local extension scaffold
-php glueful extensions:enable <name>     # Enable extension (dev only)
-php glueful extensions:disable <name>    # Disable extension (dev only)
+php glueful create:extension <name>      # Scaffold a new extension (composer package + path repo)
+php glueful extensions:enable <name>     # Add provider to `enabled` + recompile (dev only)
+php glueful extensions:disable <name>    # Remove provider from `enabled` + recompile (dev only)
 ```
 
-**Note**: `enable` and `disable` are development helpers that print exact changes to make in `config/extensions.php`; they do not modify files automatically.
+**Note**: `enable`/`disable` actually edit `config/extensions.php` and recompile the cache.
+They **validate before writing** — enabling an extension whose dependency isn't enabled (or
+disabling one another enabled extension depends on) is refused, leaving the config untouched.
+Both accept the package name, provider FQCN, or slug (slug is case-insensitive), and support
+`--dry-run` and `--backup`. They're disabled in production — there, edit `config/extensions.php`
+and run `extensions:cache` in your deploy step.
 
 ### Example CLI Output
 
 ```bash
 $ php glueful extensions:list
-✓ App\Extensions\BlogProvider (enabled, composer)
-✓ App\Extensions\ShopProvider (enabled, local scan)
-✗ App\Extensions\TestProvider (disabled in config)
-✓ VendorPackage\CmsProvider (enabled, composer)
+St  Package                Provider                                 Requires     Version
+----------------------------------------------------------------------------------------------------
+✓ glueful/blog            Glueful\Blog\BlogServiceProvider          >=1.46.0     v1.2.0
+○ vendor/analytics        Vendor\Analytics\AnalyticsServiceProvider *            v0.4.1
+⚠ (not installed)         Glueful\Shop\ShopServiceProvider          -            n/a
 
-$ php glueful extensions:why BlogProvider
-Analyzing provider: App\Extensions\BlogProvider
-
-✓ Status: INCLUDED in final provider list
-
-Discovery Analysis:
-✓ Found in: Composer packages (package: vendor/myapp/blog-extension)
-- Local scanning disabled in production
-
-Configuration Impact:
-✓ Reason: NOT in extensions.disabled blacklist
-
-Load Order & Dependencies:
-Priority: 0
-Dependencies: none
-Load position: 2 of 3
-
-$ php glueful extensions:summary
-Extensions: 3 loaded, 1 disabled, 2 deferred
-Cache: enabled (built 2 hours ago)
-Boot time: 45ms (12ms discovery, 33ms registration)
+Summary:
+Enabled:             1
+Available (off):     1
+Enabled-but-missing: 1
+Cache used:          no
 ```
 
 ## Real-World Example
@@ -443,7 +414,10 @@ Boot time: 45ms (12ms discovery, 33ms registration)
     "extra": {
         "glueful": {
             "provider": "Glueful\\Blog\\BlogServiceProvider",
-            "minVersion": "1.0.0"
+            "requires": {
+                "glueful": ">=1.46.0",
+                "extensions": []
+            }
         }
     }
 }
@@ -640,10 +614,10 @@ php glueful extensions:cache
 
 #### Development Mode
 
-- Cache expires after 5 seconds by default (configurable via `EXTENSIONS_CACHE_TTL_DEV`)
-- Local extensions scanned on each request if `extensions.local_path` is set
-- Full discovery mode enabled including composer packages
-- Supports development commands for enabling/disabling extensions
+- Resolves live from Composer + the `enabled` list on each boot (no cache required).
+- The compiled cache, if present, expires after 5 seconds by default (configurable via `EXTENSIONS_CACHE_TTL_DEV`).
+- `extensions:enable` / `extensions:disable` edit the `enabled` list and recompile.
+- **Production differs:** it boots only from the compiled manifest and fails fast if it's missing — always run `extensions:cache` in your deploy step.
 
 ## Troubleshooting
 
@@ -712,11 +686,12 @@ For frontend assets, use `mountStatic()` in development or serve via CDN in prod
 
 The extension system includes multiple security features:
 
-- **Path traversal protection** in `mountStatic()`
-- **File size limits** for local extension scanning (100KB max)
-- **Symlink detection** to prevent traversal
-- **Graceful error handling** - failures don't crash the system
-- **PSR-3 logging** for security events
+- **Explicit allow-list** — nothing loads unless its provider FQCN is in `enabled`; installing a package does not auto-activate it.
+- **Strict production manifest** — production boots only from the compiled cache (`extensions:cache`), so what loads is reviewed and deterministic.
+- **Validate-before-write** — `enable`/`disable` refuse to leave the config in a broken state (missing dependency, version mismatch, cycle).
+- **Path traversal protection** in `mountStatic()`.
+- **Graceful error handling** — a provider failing to boot is logged, not fatal.
+- **PSR-3 logging** for security events.
 
 ## Summary
 

--- a/content/6.cookbook/3.di-and-services.md
+++ b/content/6.cookbook/3.di-and-services.md
@@ -330,9 +330,9 @@ public static function services(): array
 
 Service providers organize service registration and lifecycle.
 
-Enable providers via config:
-- App providers: `config/serviceproviders.php` (`enabled`, `dev_only`, or `only` for allow‑list)
-- Vendor extensions: `config/extensions.php` (`enabled`, `dev_only`, `disabled`, optional Composer scan)
+Enable providers via config — both files use a single `enabled` list of plain string FQCNs:
+- App providers: `config/serviceproviders.php` → `enabled` (always loaded, in order).
+- Composer-discovered extensions: `config/extensions.php` → `enabled` (an installed `glueful-extension` does nothing until its provider FQCN is listed; manage with `extensions:enable|disable`).
 
 Example provider:
 

--- a/content/8.cli-reference.md
+++ b/content/8.cli-reference.md
@@ -114,9 +114,14 @@ php glueful extensions:disable billing
 php glueful extensions:cache
 php glueful extensions:clear
 php glueful extensions:summary
-php glueful extensions:why Some\\Provider\\Class
 php glueful extensions:diagnose
 ```
+
+`extensions:enable` / `extensions:disable` accept a package name, provider FQCN, or
+slug (case-insensitive), validate the change before writing to `config/extensions.php`,
+and recompile the cache. `extensions:list` shows each extension's state
+(`enabled ✓` / `available ○` / `enabled-but-missing ⚠`). In production, manage the
+`enabled` list in config and run `extensions:cache` during deploy.
 
 ## Security / Auth
 

--- a/content/releases.md
+++ b/content/releases.md
@@ -9,6 +9,7 @@ description: Curated highlights, migration guidance, and structured summaries of
 
 | Version | Codename | Date | Type | Risk | Primary Theme |
 | ------- | -------- | ---- | ---- | ---- | ------------- |
+| 1.47.0 | Hadar | 2026-05-30 | Minor | High | Extension System Re-Architecture — composer-only discovery, single `enabled` allow-list, pure resolver (breaking config change) |
 | 1.46.0 | Gienah | 2026-05-28 | Minor | Low | Fluent Query Caching — `QueryBuilder::cache(ttl, tags)` wired to `QueryCacheService`; level-8 hardening kickoff |
 | 1.45.0 | Fomalhaut | 2026-05-27 | Minor | Moderate | The Second Factor — core email-PIN 2FA (opt-in), selectRaw() bindings, security docs |
 | 1.44.0 | Errai | 2026-05-22 | Minor | Moderate | Closing the Trust Gaps — real cache tagging, archive restore, honest security report |
@@ -78,6 +79,51 @@ description: Curated highlights, migration guidance, and structured summaries of
 | 1.2.0 | Vega    | 2025-09-23 | Feature+Breaking | Medium | Tasks & Jobs overhaul |
 | 1.1.0 | Polaris | 2025-09-22 | Infra | Low  | Testing infrastructure |
 | 1.0.0 | Aurora  | 2025-09-20 | Major | High | First stable split |
+
+## v1.47.0 - Hadar
+**Released: May 30, 2026**
+
+::u-alert{color="warning" variant="subtle" icon="i-tabler-puzzle"}
+#description
+The extension system is rebuilt around a single model: **Composer discovers, one `enabled` list activates, a pure resolver orders and validates.** The four overlapping discovery sources, the multi-key config files, and the dev↔prod parity hazard are gone. This is a **breaking config change** — `config/extensions.php` and `config/serviceproviders.php` become a single `enabled` list of plain string FQCNs. Shipped as a minor per the pre-public policy; see the migration guide.
+::
+
+### Key Highlights
+
+::card
+#title
+One Discovery Path, One Allow-List
+#description
+Discovery is now **Composer-only**: installed `glueful-extension` packages are the candidates, and `config/extensions.php` → `enabled` is the single activation allow-list. Installing a package no longer auto-loads it — its provider FQCN must be enabled. The old `only` / `dev_only` / `disabled` / `local_path` / `scan_composer` keys, the local-folder scan, runtime PSR-4 registration, and `ProviderLocator` are removed. App providers move to the same single-key shape in `config/serviceproviders.php`.
+::
+
+::card
+#title
+Pure Resolver, No Dev↔Prod Drift
+#description
+A pure `ExtensionResolver` selects from `enabled`, validates (missing provider/dependency, framework-version mismatch via `composer/semver`, dependency cycle), and topologically orders providers — reading no environment, so development and production resolve identically. A single shared `ProviderClassResolver` is used by both the `ExtensionManager` and the container factory, so there is one resolution implementation, not two that drift. Production boots only from the compiled manifest (`extensions:cache`) and fails fast if it's missing.
+::
+
+::card
+#title
+CLI That Can't Leave You Broken
+#description
+`extensions:enable` / `extensions:disable` **validate before writing** — enabling an extension whose dependency isn't enabled, or disabling one another enabled extension depends on, is refused and the config is left untouched. They accept the package name, provider FQCN, or slug (case-insensitive), edit the `enabled` list, and recompile the cache. `extensions:list` shows each extension's state (`enabled ✓` / `available ○` / `enabled-but-missing ⚠`) and folds in the old `extensions:why`. `create:extension` now scaffolds a real Composer package + path repository.
+::
+
+### Migration Notes
+
+- **Breaking config change.** Convert `config/extensions.php` and `config/serviceproviders.php` to the single `enabled` list of plain string FQCNs (no `::class`). Map old keys per [`docs/EXTENSIONS_UPGRADE.md`](https://github.com/glueful/framework/blob/main/docs/EXTENSIONS_UPGRADE.md): `only`→`enabled`, `disabled`→omit, `dev_only`→`enabled` + `require-dev`, `local_path`→Composer path repository, `scan_composer`→removed.
+- **New dependency.** Adds `composer/semver` to the framework's `require` — run `composer update glueful/framework` so it installs (the resolver fatals at boot without it).
+- **Enable explicitly; cache in production.** `composer require` an extension, then `php glueful extensions:enable <name>`. Add `php glueful extensions:cache` to your production deploy step — production no longer resolves live.
+
+```bash
+composer update glueful/framework
+php glueful extensions:enable <name>
+php glueful extensions:cache   # required in production
+```
+
+---
 
 ## v1.46.0 - Gienah
 **Released: May 28, 2026**


### PR DESCRIPTION
Bring the extension docs in line with the composer-only / single-`enabled` model shipped in framework 1.47.0:

- cookbook/24.extensions.md: single-key config model; removed only/dev_only/ disabled/local_path/scan_composer; install≠enabled; validate-before-write enable/disable; strict cache; new list/diagnose output; requires vs minVersion; resolution by package/FQCN/slug (not the meta registry).
- 8.cli-reference.md, 6.cookbook/22.console-commands.md: drop extensions:why, add diagnose + enable/disable semantics.
- 6.cookbook/3.di-and-services.md: single `enabled` list for both config files.
- releases.md: 1.47.0 — Hadar summary row + curated section.