### PR TITLE
docs: router PATCH/OPTIONS, closure cache limits, precedence model + …

### DIFF
--- a/content/2.essentials/1.routing.md
+++ b/content/2.essentials/1.routing.md
@@ -26,9 +26,17 @@ $router->post('/users', [UserController::class, 'store']);
 $router->get('/users', ...);
 $router->post('/users', ...);
 $router->put('/users/{id}', ...);
+$router->patch('/users/{id}', ...);
 $router->delete('/users/{id}', ...);
 $router->head('/status', ...);
+$router->options('/users', ...);
 ```
+
+`OPTIONS` is answered automatically for CORS preflight (a `204` with an `Allow`
+header listing the methods registered for that path), so you only need
+`$router->options(...)` when you want to take over preflight with your own
+handler — an explicit `OPTIONS` route takes precedence over the automatic
+response.
 
 ## Route Parameters
 
@@ -141,7 +149,11 @@ class UserController
 }
 ```
 
-Generic route attribute:
+Shorthand method attributes are available for each verb —
+`#[Get]`, `#[Post]`, `#[Put]`, `#[Patch]`, `#[Delete]`, `#[Options]` — under
+`Glueful\Routing\Attributes`.
+
+Generic route attribute (one or more methods):
 
 ```php
 use Glueful\Routing\Attributes\Route;
@@ -152,6 +164,13 @@ class HealthController
     public function index(): Response
     {
         return Response::success(['ok' => true]);
+    }
+
+    // The methods array accepts GET, POST, PUT, PATCH, DELETE, HEAD and OPTIONS.
+    #[Route('/resource/{id}', methods: ['PUT', 'PATCH'], where: ['id' => '\d+'])]
+    public function replaceOrUpdate(int $id): Response
+    {
+        return Response::success(['id' => $id]);
     }
 }
 ```
@@ -166,3 +185,26 @@ php glueful route:cache:clear
 ```
 
 Do not rely on a `route:cache` command unless it has been added to your installed framework version.
+
+### Closure handlers are not cached
+
+The route cache compiles handlers to a serializable form, and **closures cannot
+be serialized**. When the router detects any route that uses a closure handler,
+it **skips writing the cache entirely** (and logs which routes are responsible),
+and on load it discards a cache file that still contains closure placeholders.
+The routes keep working — they are just resolved live on every request, with no
+compiled-cache speedup.
+
+This is fine for prototyping, but for production routing performance use a
+cacheable handler instead of a closure:
+
+```php
+// Not cacheable — resolved live on every request:
+$router->get('/welcome', fn() => Response::success(['ok' => true]));
+
+// Cacheable — array or string handler:
+$router->get('/welcome', [WelcomeController::class, 'index']);
+```
+
+Attribute-defined routes always use `[Controller::class, 'method']` handlers, so
+they are always cacheable.

--- a/content/6.cookbook/1.routing.md
+++ b/content/6.cookbook/1.routing.md
@@ -461,6 +461,8 @@ $router->bind('user', function($value) {
 
 Routes are automatically cached in production. In development, route cache uses a short TTL and auto‑invalidates when route files change (including framework routes). No CLI is required to manage route cache.
 
+> **Closure handlers are not cached.** Closures can't be serialized, so when the router sees any closure handler it skips writing the route cache (logging which routes are responsible) and resolves those routes live on every request. For cacheable, production‑grade routing, use `[Controller::class, 'method']` (or string) handlers rather than closures. Attribute routes are always controller handlers, so they always cache.
+
 ### Not Found / Method Not Allowed
 
 The router standardizes JSON error responses for 404 Not Found and 405 Method Not Allowed (405 responses include an `Allow` header). No explicit fallback route is needed.
@@ -476,12 +478,34 @@ The router uses several optimization techniques:
 3. **Compiled Patterns**: Regex patterns pre-compiled and cached
 4. **Reflection Caching**: Method/parameter reflection cached
 
+### Route Precedence
+
+The router resolves a request in three tiers:
+
+1. **Static routes win first.** An exact path like `/users/popular` always beats a dynamic `/users/{id}`, no matter which was registered first — static routes are matched from a hash table before any pattern matching.
+2. **Literal first segment beats a parameter first segment.** `/users/{id}` is preferred over `/{resource}/{id}` for a request to `/users/5`, independent of registration order.
+3. **Within the same first-segment group there is no specificity ranking** — overlapping dynamic patterns are tried in **registration order**, and the first that matches wins.
+
+Because of tier 3, when two dynamic patterns can match the same path, **register the more specific one first**:
+
+```php
+// Correct: specific before generic
+$router->get('/posts/{id}/edit', [PostController::class, 'edit']);
+$router->get('/posts/{id}/{action}', [PostController::class, 'action']);
+
+// Wrong: the generic pattern shadows /posts/{id}/edit, which is never reached
+$router->get('/posts/{id}/{action}', [PostController::class, 'action']);
+$router->get('/posts/{id}/edit', [PostController::class, 'edit']); // unreachable for /posts/5/edit
+```
+
+Parameters match exactly one path segment (default constraint `[^/]+`), so routes with different segment counts never collide.
+
 ### Optimization Tips
 
 ```php
-// 1. Place static routes before dynamic ones (automatic with bucketing)
-$router->get('/users/popular', $handler);  // Checked first
-$router->get('/users/{id}', $handler);     // Checked second
+// 1. Static routes always beat dynamic ones (handled automatically; no ordering needed)
+$router->get('/users/popular', $handler);  // Exact match, checked first
+$router->get('/users/{id}', $handler);     // Pattern match, checked second
 
 // 2. Use specific constraints to fail fast
 $router->get('/users/{id}', $handler)->where('id', '\d+');
@@ -527,7 +551,8 @@ RouteManifest::load($router);
 $router->get('/users', [UserController::class, 'index']);       // List
 $router->get('/users/{id}', [UserController::class, 'show']);   // Show
 $router->post('/users', [UserController::class, 'store']);      // Create
-$router->put('/users/{id}', [UserController::class, 'update']); // Update
+$router->put('/users/{id}', [UserController::class, 'update']); // Replace
+$router->patch('/users/{id}', [UserController::class, 'patch']); // Partial update
 $router->delete('/users/{id}', [UserController::class, 'destroy']); // Delete
 ```
 

--- a/content/releases.md
+++ b/content/releases.md
@@ -9,6 +9,7 @@ description: Curated highlights, migration guidance, and structured summaries of
 
 | Version | Codename | Date | Type | Risk | Primary Theme |
 | ------- | -------- | ---- | ---- | ---- | ------------- |
+| 1.48.0 | Imai | 2026-05-31 | Minor | Low | Router Verb Completeness — first-class `PATCH`/`OPTIONS`, explicit `OPTIONS` beats auto-CORS, documented route precedence |
 | 1.47.0 | Hadar | 2026-05-30 | Minor | High | Extension System Re-Architecture — composer-only discovery, single `enabled` allow-list, pure resolver (breaking config change) |
 | 1.46.0 | Gienah | 2026-05-28 | Minor | Low | Fluent Query Caching — `QueryBuilder::cache(ttl, tags)` wired to `QueryCacheService`; level-8 hardening kickoff |
 | 1.45.0 | Fomalhaut | 2026-05-27 | Minor | Moderate | The Second Factor — core email-PIN 2FA (opt-in), selectRaw() bindings, security docs |
@@ -79,6 +80,48 @@ description: Curated highlights, migration guidance, and structured summaries of
 | 1.2.0 | Vega    | 2025-09-23 | Feature+Breaking | Medium | Tasks & Jobs overhaul |
 | 1.1.0 | Polaris | 2025-09-22 | Infra | Low  | Testing infrastructure |
 | 1.0.0 | Aurora  | 2025-09-20 | Major | High | First stable split |
+
+## v1.48.0 - Imai
+**Released: May 31, 2026**
+
+::u-alert{color="primary" variant="subtle" icon="i-tabler-route"}
+#description
+`PATCH` and `OPTIONS` become first-class routing verbs — both were previously unreachable through the public routing API. Explicit `OPTIONS` routes now win over the automatic CORS preflight responder, and the router's route-precedence model is documented and locked down with tests. Purely additive: no breaking changes, no new env vars, no migrations.
+::
+
+### Key Highlights
+
+::card
+#title
+First-Class PATCH and OPTIONS
+#description
+New `$router->patch()` and `$router->options()` shortcuts join `get`/`post`/`put`/`delete`/`head`, with matching `#[Patch]` and `#[Options]` attributes. The generic `#[Route(methods: [...])]` form now accepts `PATCH`, `OPTIONS` and `HEAD` too — previously it threw `InvalidArgumentException` for anything but GET/POST/PUT/DELETE, so `PATCH` (the standard partial-update verb) had no public route-registration path at all.
+::
+
+::card
+#title
+Explicit OPTIONS Beats Auto-CORS
+#description
+`Router::dispatch()` still answers `OPTIONS` automatically for CORS preflight (a `204` with an `Allow` header) when no `OPTIONS` route is registered. But an explicitly registered `OPTIONS` route now runs its own handler instead of being silently shadowed by the preflight responder — so you can take over preflight when you need to, and the automatic behavior remains the default everywhere else.
+::
+
+::card
+#title
+Route Precedence, Documented and Pinned
+#description
+The router's precedence model is now explicit: **static routes beat dynamic ones**; a **literal first segment beats a parameter first segment** (`/users/{id}` over `/{resource}/{id}`, independent of order); and **within a first-segment group, registration order wins** — so register the more specific overlapping pattern first. The model is locked down by `RoutePrecedenceTest`, and a misleading in-code comment claiming a specificity sort that never existed was corrected.
+::
+
+### Migration Notes
+
+- **No action required.** Framework-only, fully backward-compatible release — no migrations, no env vars, no breaking changes. `composer update` is sufficient.
+- The existing api-skeleton `^1.47.0` constraint already permits 1.48.0; the skeleton constraint is bumped to `^1.48.0` for clarity.
+
+```bash
+composer update glueful/framework
+```
+
+---
 
 ## v1.47.0 - Hadar
 **Released: May 30, 2026**


### PR DESCRIPTION
…v1.48.0 Imai

- routing essentials: patch()/options() methods, full shorthand attribute set, 'closures are not cached' note
- cookbook: new Route Precedence section + route-cache closure caveat; fix misleading 'automatic with bucketing' comment
- releases: 1.48.0 Imai summary row (Minor/Low) + full entry