### PR TITLE
Bump to v1.61.1; add release notes

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -30,7 +30,7 @@ export default defineAppConfig({
     title: '',
     to: '/',
     // Current framework version shown next to the logo — bump on each framework release.
-    version: '1.61.0',
+    version: '1.61.1',
     logo: {
       alt: '',
       light: '',

--- a/content/releases.md
+++ b/content/releases.md
@@ -5,6 +5,31 @@ description: Curated highlights, migration guidance, and structured summaries of
 
 > This page is a curated layer over the raw authoritative `CHANGELOG.md`. For complete detail (including every Added/Changed/Removed/Fix line) consult the full changelog.
 
+## v1.61.1 - Wezen
+**Released: June 22, 2026**
+
+::u-alert{color="info" variant="subtle" icon="i-tabler-world-www"}
+#description
+**CORS on every response.** Cross-origin **error** and regular responses (422, 401, …) now carry `Access-Control-Allow-Origin`, so a separately-served frontend (e.g. a Vite dev SPA on another origin) can finally read their bodies. Previously only the OPTIONS preflight got CORS headers, leaving regular and error bodies blocked by the browser. **Bugfix patch** — no new env, no migrations, no action required.
+::
+
+### Key Highlights
+
+::card
+#title
+CORS headers on regular and error responses
+#description
+`Application::handle()` now applies CORS to the **final** response in both the dispatch and exception-handler branches — the single chokepoint that sees success **and** error paths. A new public `Cors::applyToResponse(Request, Response)` decorates an already-built response with the regular-request CORS headers (`Access-Control-Allow-Origin`, `Vary: Origin`, and per-config `Expose-Headers` / `Allow-Credentials`). It is a no-op when there is no `Origin`, the origin is not allowed, or the header is already set — so it never clobbers the router's preflight responder.
+::
+
+### Migration Notes
+
+- **Nothing required.** Same-origin requests and disallowed origins are unchanged; allowed cross-origin requests now receive the CORS headers they should always have had on regular and error responses.
+
+```bash
+composer update glueful/framework
+```
+
 ## v1.61.0 - Wezen
 **Released: June 20, 2026**
 


### PR DESCRIPTION
Update app config version to 1.61.1 and add the v1.61.1 release entry. The notes document a bugfix that applies CORS headers to final responses (including error responses) via a new Cors::applyToResponse hook in Application::handle, allowing cross-origin frontends to read response bodies. No migrations or env changes required; includes composer update reminder.