### PR TITLE
v1.63.3: Fix blob write auditability

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -30,7 +30,7 @@ export default defineAppConfig({
     title: '',
     to: '/',
     // Current framework version shown next to the logo — bump on each framework release.
-    version: '1.63.2',
+    version: '1.63.3',
     logo: {
       alt: '',
       light: '',

--- a/content/releases.md
+++ b/content/releases.md
@@ -5,6 +5,22 @@ description: Curated highlights, migration guidance, and structured summaries of
 
 > This page is a curated layer over the raw authoritative `CHANGELOG.md`. For complete detail (including every Added/Changed/Removed/Fix line) consult the full changelog.
 
+## v1.63.3 - Yildun
+**Released: June 26, 2026**
+
+::u-alert{color="warning" variant="subtle" icon="i-tabler-bug"}
+#description
+**Blob writes are now auditable.** `BlobRepository` was constructed without an `ApplicationContext`, so its create/update/delete never dispatched entity events — blob **uploads emitted no `EntityCreatedEvent`** and silently couldn't be audited. It's now built with the context, so uploads emit events an audit/activity consumer can record. **Bugfix patch** — no new env, no migrations.
+::
+
+### Migration Notes
+
+- **Nothing required.** Bugfix only.
+
+```bash
+composer update glueful/framework
+```
+
 ## v1.63.2 - Yildun
 **Released: June 26, 2026**
 


### PR DESCRIPTION
Release v1.63.3 - Yildun

Bugfix patch that makes blob writes auditable. BlobRepository was constructed without an ApplicationContext, preventing it from dispatching entity events. Blob uploads now properly emit EntityCreatedEvent for audit/activity consumers to record.

No new environment variables or migrations required.