### PR TITLE
Bump version to v1.63.4 and add release notes

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -30,7 +30,7 @@ export default defineAppConfig({
     title: '',
     to: '/',
     // Current framework version shown next to the logo — bump on each framework release.
-    version: '1.63.3',
+    version: '1.63.4',
     logo: {
       alt: '',
       light: '',

--- a/content/releases.md
+++ b/content/releases.md
@@ -5,6 +5,31 @@ description: Curated highlights, migration guidance, and structured summaries of
 
 > This page is a curated layer over the raw authoritative `CHANGELOG.md`. For complete detail (including every Added/Changed/Removed/Fix line) consult the full changelog.
 
+## v1.63.4 - Yildun
+**Released: June 27, 2026**
+
+::u-alert{color="info" variant="subtle" icon="i-tabler-api"}
+#description
+**The webhook management API is now self-documenting.** The framework ships a complete `WebhookController` (subscription + delivery management), but its methods carried no OpenAPI attributes — so an application that mounts these routes got working endpoints that were invisible to `generate:openapi` and the typed client. All 11 endpoints now carry `#[ApiOperation]`/`#[ApiResponse]`. **Patch** — documentation metadata only, no behavioral change, no new env, no migrations.
+::
+
+### Key Highlights
+
+::card
+#title
+`WebhookController` endpoints appear in generated docs
+#description
+The 11 webhook-management methods — subscription list/create/get/update/delete, rotate-secret, test, stats, plus delivery list/get/retry — now carry `#[ApiOperation]` + `#[ApiResponse]` attributes. Applications that mount the controller (the core does not auto-register these routes) pick them up in `openapi.json` and the typed client, exactly like any other annotated controller. Nothing about the routes, behavior, or signatures changed.
+::
+
+### Migration Notes
+
+- **Nothing required.** Documentation metadata only. After `composer update`, re-run `generate:openapi` (and your client codegen) to surface the webhook endpoints in your spec.
+
+```bash
+composer update glueful/framework
+```
+
 ## v1.63.3 - Yildun
 **Released: June 26, 2026**
 


### PR DESCRIPTION
Update app config version to 1.63.4 and add release notes for v1.63.4. Notes document that the WebhookController endpoints are now annotated with #[ApiOperation]/#[ApiResponse], making the 11 webhook-management routes appear in generated OpenAPI and typed clients. This is documentation metadata only — no behavior changes or migrations. Instructs users to run `composer update glueful/framework` and re-run `generate:openapi` to surface the endpoints.