### PR TITLE
Release v1.65.2 - FieldSelector param fix

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -30,7 +30,7 @@ export default defineAppConfig({
     title: '',
     to: '/',
     // Current framework version shown next to the logo — bump on each framework release.
-    version: '1.65.1',
+    version: '1.65.2',
     logo: {
       alt: '',
       light: '',

--- a/content/releases.md
+++ b/content/releases.md
@@ -5,6 +5,31 @@ description: Curated highlights, migration guidance, and structured summaries of
 
 > This page is a curated layer over the raw authoritative `CHANGELOG.md`. For complete detail (including every Added/Changed/Removed/Fix line) consult the full changelog.
 
+## v1.65.2 - Acrux
+**Released: July 2, 2026**
+
+::u-alert{color="success" variant="subtle" icon="i-tabler-bug"}
+#description
+**Array-valued field-selection params no longer 500.** A public read/delivery endpoint that builds its `FieldSelector` from the request would return an unhandled 500 when a client sent `fields`/`expand` as an array (`?fields[]=a`), because Symfony's `InputBag` rejects non-scalar values. Field selection is a scalar syntax, so those params are now read tolerantly and an array value is treated as "no selection". **Patch** — bugfix only, no new env, no migrations, no behavioral changes.
+::
+
+### Key Highlights
+
+::card
+#title
+`FieldSelector` tolerates malformed array params
+#description
+`FieldSelector::fromRequest()` and `fromRequestAdvanced()` read `fields`/`expand` via `Request::query->get()`, which throws a `BadRequestException` when the parameter arrives as an array — surfacing as a 500 on any public endpoint that derives its selector from the request. Both factories now read via `query->all()` and treat any non-string value as absent, landing on the existing "no field selection" fast path. Scalar `fields`/`expand` parse exactly as before, so nothing changes for well-formed requests.
+::
+
+### Migration Notes
+
+- **Nothing required.** Pure bugfix patch — no new env, no migrations, no behavioral changes.
+
+```bash
+composer update glueful/framework
+```
+
 ## v1.65.1 - Acrux
 **Released: July 1, 2026**
 


### PR DESCRIPTION
Bump version to 1.65.2 and add release notes. Fixes a 500 error that occurred when array-valued field-selection parameters (fields/expand) were sent in requests. FieldSelector now tolerantly handles malformed array params and treats them as absent instead of throwing an exception.